### PR TITLE
feat: 역할 분석 기능 추가 (파일 경로 기반)

### DIFF
--- a/src/main/java/com/tally/domain/Commit.java
+++ b/src/main/java/com/tally/domain/Commit.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 public class Commit {
@@ -14,6 +16,9 @@ public class Commit {
 
     private User author;
     private User committer;
+
+    // 파일 정보 추가
+    private List<CommitFile> files;
 
     @Getter
     @Setter
@@ -29,5 +34,18 @@ public class Commit {
             private String email;
             private String date;
         }
+    }
+
+    @Getter
+    @Setter
+    public static class CommitFile {
+        private String filename;
+        private String status;  // added, modified, removed
+        private int additions;
+        private int deletions;
+        private int changes;
+
+        @JsonProperty("blob_url")
+        private String blobUrl;
     }
 }

--- a/src/main/java/com/tally/domain/ContributionStats.java
+++ b/src/main/java/com/tally/domain/ContributionStats.java
@@ -4,11 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.Map;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -31,5 +33,19 @@ public class ContributionStats {
     private Map<Integer, Integer> hourlyActivity;       // 시간대별 커밋 수
     private Map<String, Integer> dailyActivity;         // 요일별 커밋 수
 
+    // 역할 분석
+    private Map<String, RoleStats> roleDistribution;    // 역할별 통계
+
     private LocalDateTime analyzedAt;
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RoleStats {
+        private String roleName;
+        private int commitCount;
+        private double percentage;
+    }
 }

--- a/src/main/java/com/tally/service/ContributionAnalysisService.java
+++ b/src/main/java/com/tally/service/ContributionAnalysisService.java
@@ -6,7 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -30,17 +30,24 @@ public class ContributionAnalysisService {
 
         // 4. 커밋 통계 계산
         long totalCommits = commits.size();
-        long userCommits = commits.stream()
+        List<Commit> userCommitList = commits.stream()
                 .filter(commit -> commit.getCommit() != null
                         && commit.getCommit().getAuthor() != null
                         && username.equals(commit.getCommit().getAuthor().getName()))
-                .count();
+                .collect(Collectors.toList());
+
+        long userCommits = userCommitList.size();
 
         double commitPercentage = totalCommits > 0
                 ? (double) userCommits / totalCommits * 100
                 : 0.0;
 
-        // 5. ContributionStats 생성 (Builder 패턴 사용)
+        // 5. 역할 분석 수행
+        Map<String, ContributionStats.RoleStats> roleDistribution = analyzeRoles(
+                token, owner, repo, username, userCommitList
+        );
+
+        // 6. ContributionStats 생성 (Builder 패턴 사용)
         ContributionStats stats = ContributionStats.builder()
                 .id(java.util.UUID.randomUUID().toString())
                 .userId(username)
@@ -48,13 +55,127 @@ public class ContributionAnalysisService {
                 .totalCommits((int) totalCommits)
                 .userCommits((int) userCommits)
                 .commitPercentage(commitPercentage)
+                .roleDistribution(roleDistribution)
                 .analyzedAt(LocalDateTime.now())
                 .build();
 
-        log.info("Contribution analysis completed for {}/{} - User: {}, Commits: {}/{}, PRs: {}, Issues: {}",
-                owner, repo, username, userCommits, totalCommits, pullRequests.size(), issues.size());
+        log.info("Contribution analysis completed for {}/{} - User: {}, Commits: {}/{}, Roles: {}",
+                owner, repo, username, userCommits, totalCommits, roleDistribution.keySet());
 
         return stats;
+    }
+
+    /**
+     * 역할 분석
+     */
+    private Map<String, ContributionStats.RoleStats> analyzeRoles(
+            String token, String owner, String repo, String username, List<Commit> userCommits) {
+
+        Map<String, Integer> roleCommitCount = new HashMap<>();
+        int totalAnalyzedCommits = 0;
+
+        for (Commit commit : userCommits) {
+            // 커밋 상세 정보 조회 (파일 목록 포함)
+            Commit detailedCommit = gitHubService.getCommitDetail(token, owner, repo, commit.getSha());
+
+            if (detailedCommit == null || detailedCommit.getFiles() == null) {
+                continue;
+            }
+
+            totalAnalyzedCommits++;
+
+            // 이 커밋에서 변경된 파일들을 역할로 분류
+            Set<String> rolesInCommit = new HashSet<>();
+
+            for (Commit.CommitFile file : detailedCommit.getFiles()) {
+                String role = categorizeFile(file.getFilename());
+                rolesInCommit.add(role);
+            }
+
+            // 각 역할에 커밋 카운트 추가
+            for (String role : rolesInCommit) {
+                roleCommitCount.put(role, roleCommitCount.getOrDefault(role, 0) + 1);
+            }
+        }
+
+        // RoleStats 객체로 변환
+        Map<String, ContributionStats.RoleStats> roleDistribution = new HashMap<>();
+
+        for (Map.Entry<String, Integer> entry : roleCommitCount.entrySet()) {
+            String roleName = entry.getKey();
+            int commitCount = entry.getValue();
+            double percentage = totalAnalyzedCommits > 0
+                    ? (double) commitCount / totalAnalyzedCommits * 100
+                    : 0.0;
+
+            roleDistribution.put(roleName, ContributionStats.RoleStats.builder()
+                    .roleName(roleName)
+                    .commitCount(commitCount)
+                    .percentage(percentage)
+                    .build());
+        }
+
+        return roleDistribution;
+    }
+
+    /**
+     * 파일 경로를 기반으로 역할 분류
+     */
+    private String categorizeFile(String filename) {
+        String lowerFilename = filename.toLowerCase();
+
+        // 백엔드
+        if (lowerFilename.contains("src/main/java") ||
+                lowerFilename.endsWith(".java") ||
+                lowerFilename.contains("controller") ||
+                lowerFilename.contains("service") ||
+                lowerFilename.contains("repository") ||
+                lowerFilename.contains("domain")) {
+            return "백엔드";
+        }
+
+        // 프론트엔드
+        if (lowerFilename.contains("src/components") ||
+                lowerFilename.contains("src/pages") ||
+                lowerFilename.endsWith(".jsx") ||
+                lowerFilename.endsWith(".tsx") ||
+                lowerFilename.endsWith(".vue") ||
+                lowerFilename.contains("frontend")) {
+            return "프론트엔드";
+        }
+
+        // 인프라/DevOps
+        if (lowerFilename.contains("dockerfile") ||
+                lowerFilename.contains("docker-compose") ||
+                lowerFilename.contains(".github/workflows") ||
+                lowerFilename.contains("terraform") ||
+                lowerFilename.contains(".yml") ||
+                lowerFilename.contains(".yaml")) {
+            return "인프라";
+        }
+
+        // 테스트
+        if (lowerFilename.contains("test") ||
+                lowerFilename.contains("spec")) {
+            return "테스트";
+        }
+
+        // 문서
+        if (lowerFilename.endsWith(".md") ||
+                lowerFilename.contains("readme") ||
+                lowerFilename.contains("docs/")) {
+            return "문서";
+        }
+
+        // 설정
+        if (lowerFilename.contains("config") ||
+                lowerFilename.contains("gradle") ||
+                lowerFilename.contains("pom.xml") ||
+                lowerFilename.contains("package.json")) {
+            return "설정";
+        }
+
+        return "기타";
     }
 
     /**

--- a/src/main/java/com/tally/service/GitHubService.java
+++ b/src/main/java/com/tally/service/GitHubService.java
@@ -72,6 +72,33 @@ public class GitHubService {
     }
 
     /**
+     * 커밋 상세 정보 조회 (파일 목록 포함)
+     */
+    public Commit getCommitDetail(String token, String owner, String repo, String sha) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "token " + token);
+        headers.set("Accept", "application/json");
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+
+        String url = String.format("https://api.github.com/repos/%s/%s/commits/%s", owner, repo, sha);
+
+        try {
+            ResponseEntity<Commit> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    request,
+                    Commit.class
+            );
+
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("Failed to fetch commit detail for sha: {}", sha, e);
+            return null;
+        }
+    }
+
+    /**
      * 레포지토리의 Pull Request 목록 조회
      */
     public List<PullRequest> getRepositoryPullRequests(String token, String owner, String repo) {


### PR DESCRIPTION
## 작업 내용
커밋의 파일 경로를 분석하여 개발자의 역할(백엔드/프론트엔드/인프라)을 자동으로 분류하고 비율을 시각화하는 기능을 추가했습니다.

## 주요 변경사항

### 1. Domain 확장
- **Commit.java**: 파일 정보(`CommitFile`) 추가
  - filename, status, additions, deletions 등
- **ContributionStats.java**: `roleDistribution` 필드 추가
  - RoleStats 내부 클래스 추가 (roleName, commitCount, percentage)

### 2. Service 확장
- **GitHubService.java**: 커밋 상세 조회 메서드 추가
  - `getCommitDetail()` - 파일 목록 포함한 커밋 상세 정보
  
- **ContributionAnalysisService.java**: 역할 분석 로직 구현
  - `analyzeRoles()` - 역할별 커밋 수 계산 및 비율 산출
  - `categorizeFile()` - 파일 경로 패턴 매칭
    ```
    src/main/java/ → 백엔드
    src/components/ → 프론트엔드
    Dockerfile, .yml → 인프라
    README.md → 문서
    ```

- **ReportGenerationService.java**: 역할 분석 섹션 추가
  - Markdown: 진행바(■□) 스타일
  - HTML: 프로그레스 바 스타일

## 테스트 결과

### 실제 리포트 출력 
<img width="635" height="283" alt="스크린샷 2025-10-07 오후 9 52 07" src="https://github.com/user-attachments/assets/7e46b935-bb45-4539-840a-bdabbe1fd751" />


### 검증 완료
- [x] 커밋별 파일 목록 조회 성공
- [x] 파일 경로 → 역할 매핑 정확성 확인
- [x] 역할별 통계 계산 정상 작동
- [x] 비율 계산 및 정렬 정확성 검증
- [x] Markdown/HTML 리포트에 역할 분석 포함
- [x] 실제 레포지토리(Tally-BE)로 테스트 완료

