### PR TITLE
feat: CORS 설정 및 GitHub API 연동 개선

### DIFF
--- a/src/main/java/com/tally/config/WebConfig.java
+++ b/src/main/java/com/tally/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.tally.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173", "http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}

--- a/src/main/java/com/tally/domain/GitHubRepository.java
+++ b/src/main/java/com/tally/domain/GitHubRepository.java
@@ -1,25 +1,48 @@
 package com.tally.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
-import java.time.LocalDateTime;
-
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Data
 public class GitHubRepository {
-    private String id;
-    private String name;                  // 레포지토리 이름
-    private String fullName;              // owner/repo
+    private Long id;
+
+    private String name;
+
+    @JsonProperty("full_name")
+    private String fullName;
+
     private String description;
+
+    @JsonProperty("private")
+    private Boolean isPrivate;
+
+    @JsonProperty("html_url")
     private String url;
-    private String owner;
-    private boolean isPrivate;
+
+    private Owner owner;  // String에서 Owner 객체로 변경!
+
+    @JsonProperty("default_branch")
     private String defaultBranch;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+
+    @JsonProperty("created_at")
+    private String createdAt;
+
+    @JsonProperty("updated_at")
+    private String updatedAt;
+
+    // Owner 내부 클래스 추가
+    @Data
+    public static class Owner {
+        private String login;  // 실제 username
+        private Long id;
+
+        @JsonProperty("avatar_url")
+        private String avatarUrl;
+    }
+
+    // 프론트엔드 호환성을 위한 헬퍼 메서드
+    public String getOwnerLogin() {
+        return owner != null ? owner.getLogin() : null;
+    }
 }


### PR DESCRIPTION
## 📋 작업 내용
프론트엔드와의 API 연동을 위한 CORS 설정 추가 및 GitHub API 응답 형식 맞춤

## 🎯 주요 변경사항

### 1. CORS 설정 추가
- **파일**: `src/main/java/com/tally/config/WebConfig.java` (신규)
- 프론트엔드(`localhost:5173`, `localhost:3000`) 요청 허용
- 모든 HTTP 메서드 및 헤더 지원

### 2. GitHubRepository 모델 수정
- **파일**: `src/main/java/com/tally/domain/GitHubRepository.java`
- `owner` 필드를 `String`에서 `Owner` 객체로 변경
- GitHub API 실제 응답 형식과 일치하도록 수정

### 3. OAuth Callback 개선
- **파일**: `src/main/java/com/tally/controller/AuthController.java`
- JSON 응답에서 프론트엔드 리다이렉트(`RedirectView`)로 변경
- 사용자 정보를 URL 파라미터로 전달

## 🐛 해결한 문제
1. **CORS 에러**: 프론트엔드 API 호출 차단 문제 해결
2. **JSON 파싱 에러**: owner 객체 파싱 문제 해결
3. **OAuth 플로우**: 자동 프론트엔드 리다이렉트 구현

## ✅ 테스트 완료
- ✅ 레포지토리 목록 조회
- ✅ 기여도 분석
- ✅ 리포트 다운로드
- ✅ OAuth 로그인 플로우
- ✅ 프론트엔드와 전체 API 연동