### PR TITLE
feat: 조직 레포지토리 지원 추가 

### DIFF
--- a/src/main/java/com/tally/controller/AnalysisController.java
+++ b/src/main/java/com/tally/controller/AnalysisController.java
@@ -17,6 +17,30 @@ public class AnalysisController {
 
     private final ContributionAnalysisService analysisService;
 
+    /**
+     * GET 방식: URL 파라미터로 분석
+     */
+    @GetMapping("/{owner}/{repo}")
+    public ResponseEntity<ContributionStats> analyzeContributionByPath(
+            @PathVariable String owner,
+            @PathVariable String repo,
+            @RequestParam(required = false) String username,
+            @RequestHeader("Authorization") String authorization) {
+
+        String accessToken = authorization.replace("Bearer ", "");
+
+        log.info("Analyzing contribution for user {} in {}/{}", username, owner, repo);
+
+        ContributionStats stats = analysisService.analyzeContribution(
+                accessToken, owner, repo, username
+        );
+
+        return ResponseEntity.ok(stats);
+    }
+
+    /**
+     * POST 방식: Body로 분석 (기존 방식 유지)
+     */
     @PostMapping("/analyze")
     public ResponseEntity<ContributionStats> analyzeContribution(
             @RequestBody Map<String, String> request,

--- a/src/main/java/com/tally/controller/AuthController.java
+++ b/src/main/java/com/tally/controller/AuthController.java
@@ -3,59 +3,102 @@ package com.tally.controller;
 import com.tally.domain.User;
 import com.tally.service.AuthService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
+
     private final AuthService authService;
 
-    /**
-     * 로그인 (Access Token 직접 입력)
-     */
+    @Value("${github.client-id}")
+    private String clientId;
+
+    @Value("${github.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${frontend.url:http://localhost:5173}")
+    private String frontendUrl;
+
+    @GetMapping("/github")
+    public ResponseEntity<Map<String, String>> getGitHubAuthUrl() {
+        // ✅ prompt=consent 추가: 매번 권한 승인 페이지 표시
+        String authUrl = String.format(
+                "https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=user:email,repo,read:org&prompt=consent",
+                clientId,
+                redirectUri
+        );
+
+        Map<String, String> response = new HashMap<>();
+        response.put("authUrl", authUrl);
+
+        log.info("Generated GitHub auth URL with prompt=consent");
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/callback")
+    public RedirectView handleGitHubCallback(@RequestParam String code) {
+        try {
+            log.info("Received GitHub callback with code: {}", code.substring(0, 5) + "...");
+
+            String accessToken = authService.getAccessToken(code);
+            User user = authService.getUserInfo(accessToken);
+
+            user.setAccessToken(accessToken);
+            authService.saveUser(user);
+
+            // 프론트엔드로 리다이렉트 (토큰과 사용자 정보 전달)
+            String redirectUrl = String.format(
+                    "%s/auth/callback?accessToken=%s&userId=%s&username=%s",
+                    frontendUrl,
+                    URLEncoder.encode(accessToken, StandardCharsets.UTF_8.toString()),
+                    URLEncoder.encode(user.getId(), StandardCharsets.UTF_8.toString()),
+                    URLEncoder.encode(user.getUsername(), StandardCharsets.UTF_8.toString())
+            );
+
+            log.info("Redirecting to frontend: {}", frontendUrl + "/auth/callback");
+
+            RedirectView redirectView = new RedirectView();
+            redirectView.setUrl(redirectUrl);
+            redirectView.setStatusCode(HttpStatus.FOUND);
+            return redirectView;
+
+        } catch (Exception e) {
+            log.error("Authentication failed", e);
+
+            RedirectView redirectView = new RedirectView();
+            redirectView.setUrl(frontendUrl + "/?error=auth_failed");
+            return redirectView;
+        }
+    }
+
     @PostMapping("/login")
     public ResponseEntity<User> login(@RequestBody Map<String, String> request) {
         String accessToken = request.get("accessToken");
-        User user = authService.login(accessToken);
-        return ResponseEntity.ok(user);
-    }
 
-    /**
-     * GitHub OAuth 로그인 페이지로 리다이렉트
-     */
-    @GetMapping("/github")
-    public ResponseEntity<?> redirectToGitHub() {
-        String authUrl = authService.getAuthorizationUrl();
-        return ResponseEntity.ok(Map.of("authUrl", authUrl));
-    }
-
-    /**
-     * GitHub OAuth Callback - 프론트엔드로 리다이렉트
-     */
-    @GetMapping("/callback")
-    public RedirectView handleCallback(@RequestParam String code) {
         try {
-            User user = authService.exchangeCodeForToken(code);
+            User user = authService.getUserInfo(accessToken);
+            user.setAccessToken(accessToken);
+            authService.saveUser(user);
 
-            // ✅ 프론트엔드로 리다이렉트 (accessToken과 user 정보를 URL 파라미터로 전달)
-            String redirectUrl = String.format(
-                    "http://localhost:5173/auth/callback?accessToken=%s&userId=%s&username=%s&avatarUrl=%s",
-                    user.getAccessToken(),
-                    user.getId(),
-                    user.getUsername(),
-                    user.getAvatarUrl() != null ? user.getAvatarUrl() : ""
-            );
-
-            return new RedirectView(redirectUrl);
+            log.info("User logged in: {}", user.getUsername());
+            return ResponseEntity.ok(user);
 
         } catch (Exception e) {
-            // 에러 시에도 프론트엔드로 리다이렉트
-            return new RedirectView("http://localhost:5173/?error=" + e.getMessage());
+            log.error("Login failed", e);
+            return ResponseEntity.badRequest().build();
         }
     }
 }

--- a/src/main/java/com/tally/controller/OrganizationController.java
+++ b/src/main/java/com/tally/controller/OrganizationController.java
@@ -1,0 +1,157 @@
+package com.tally.controller;
+
+import com.tally.domain.*;
+import com.tally.service.GitHubService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/organizations")
+@RequiredArgsConstructor
+public class OrganizationController {
+
+    private final GitHubService gitHubService;
+
+    /**
+     * 사용자가 속한 조직 목록 조회 (Grant 승인된 조직만)
+     */
+    @GetMapping
+    public ResponseEntity<List<Organization>> getUserOrganizations(
+            @RequestHeader("Authorization") String authorization) {
+
+        String accessToken = authorization.replace("Bearer ", "");
+        log.info("Fetching organizations for user");
+
+        // ✅ API에서만 가져오기 (Grant 승인된 조직)
+        List<Organization> organizations = gitHubService.getUserOrganizations(accessToken);
+
+        log.info("Returning {} organizations", organizations.size());
+        return ResponseEntity.ok(organizations);
+    }
+
+    /**
+     * 특정 조직의 상세 정보 및 사용자 기여도 통계
+     */
+    @GetMapping("/{orgName}/stats")
+    public ResponseEntity<OrganizationStats> getOrganizationStats(
+            @PathVariable String orgName,
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(required = false) String username) {
+
+        String accessToken = authorization.replace("Bearer ", "");
+        log.info("Fetching stats for organization: {}", orgName);
+
+        // 조직의 모든 레포지토리 가져오기
+        List<GitHubRepository> orgRepos = gitHubService.getOrganizationRepositories(accessToken, orgName);
+
+        int totalCommits = 0;
+        int userCommits = 0;
+        int totalIssues = 0;
+        int totalPullRequests = 0;
+
+        List<OrganizationStats.RepositoryContribution> repoContributions = new ArrayList<>();
+
+        // 각 레포지토리별 통계 계산
+        for (GitHubRepository repo : orgRepos) {
+            try {
+                List<Commit> commits = gitHubService.getRepositoryCommits(accessToken, orgName, repo.getName());
+
+                long repoUserCommits = 0;
+                if (username != null && !username.isEmpty()) {
+                    repoUserCommits = commits.stream()
+                            .filter(commit -> {
+                                if (commit.getAuthor() != null && commit.getAuthor().getLogin() != null) {
+                                    return username.equalsIgnoreCase(commit.getAuthor().getLogin());
+                                }
+                                if (commit.getCommit() != null && commit.getCommit().getAuthor() != null) {
+                                    String authorName = commit.getCommit().getAuthor().getName();
+                                    return authorName != null && authorName.equalsIgnoreCase(username);
+                                }
+                                return false;
+                            })
+                            .count();
+                }
+
+                int repoTotalCommits = commits.size();
+                totalCommits += repoTotalCommits;
+                userCommits += repoUserCommits;
+
+                double repoContributionPercentage = repoTotalCommits > 0
+                        ? (repoUserCommits * 100.0 / repoTotalCommits)
+                        : 0.0;
+
+                if (repoUserCommits > 0) {
+                    OrganizationStats.RepositoryContribution contribution = OrganizationStats.RepositoryContribution.builder()
+                            .name(repo.getName())
+                            .fullName(repo.getFullName())
+                            .url(repo.getUrl())
+                            .totalCommits(repoTotalCommits)
+                            .userCommits((int) repoUserCommits)
+                            .contributionPercentage(Math.round(repoContributionPercentage * 10.0) / 10.0)
+                            .lastUpdated(repo.getUpdatedAt())
+                            .build();
+
+                    repoContributions.add(contribution);
+                }
+
+                List<Issue> issues = gitHubService.getRepositoryIssues(accessToken, orgName, repo.getName());
+                List<PullRequest> prs = gitHubService.getRepositoryPullRequests(accessToken, orgName, repo.getName());
+
+                totalIssues += issues.size();
+                totalPullRequests += prs.size();
+
+            } catch (Exception e) {
+                log.error("Error processing repository {}: {}", repo.getName(), e.getMessage());
+            }
+        }
+
+        double overallContributionPercentage = totalCommits > 0
+                ? (userCommits * 100.0 / totalCommits)
+                : 0.0;
+
+        String avatarUrl = "";
+        String description = "";
+        if (!orgRepos.isEmpty() && orgRepos.get(0).getOwner() != null) {
+            avatarUrl = orgRepos.get(0).getOwner().getAvatarUrl();
+        }
+
+        OrganizationStats stats = OrganizationStats.builder()
+                .organizationName(orgName)
+                .avatarUrl(avatarUrl)
+                .description(description)
+                .totalRepositories(repoContributions.size())
+                .totalCommits(totalCommits)
+                .userCommits(userCommits)
+                .contributionPercentage(Math.round(overallContributionPercentage * 10.0) / 10.0)
+                .repositories(repoContributions)
+                .totalIssues(totalIssues)
+                .totalPullRequests(totalPullRequests)
+                .build();
+
+        log.info("Organization {} stats: {} repos, {}/{} commits ({}%)",
+                orgName, stats.getTotalRepositories(), userCommits, totalCommits, stats.getContributionPercentage());
+
+        return ResponseEntity.ok(stats);
+    }
+
+    /**
+     * 특정 조직의 레포지토리 목록 조회
+     */
+    @GetMapping("/{orgName}/repositories")
+    public ResponseEntity<List<GitHubRepository>> getOrganizationRepositories(
+            @PathVariable String orgName,
+            @RequestHeader("Authorization") String authorization) {
+
+        String accessToken = authorization.replace("Bearer ", "");
+        log.info("Fetching repositories for organization: {}", orgName);
+
+        List<GitHubRepository> repositories = gitHubService.getOrganizationRepositories(accessToken, orgName);
+        return ResponseEntity.ok(repositories);
+    }
+}

--- a/src/main/java/com/tally/controller/RepositoryController.java
+++ b/src/main/java/com/tally/controller/RepositoryController.java
@@ -23,9 +23,11 @@ public class RepositoryController {
             @RequestHeader("Authorization") String authorization) {
 
         String accessToken = authorization.replace("Bearer ", "");
-        log.info("Fetching repositories for user");
+        log.info("Fetching all repositories for user (personal + organizations)");
 
-        List<GitHubRepository> repositories = gitHubService.getUserRepositories(accessToken);
+        List<GitHubRepository> repositories = gitHubService.getAllRepositories(accessToken);
+
+        log.info("Returning {} total repositories", repositories.size());
         return ResponseEntity.ok(repositories);
     }
 

--- a/src/main/java/com/tally/domain/Commit.java
+++ b/src/main/java/com/tally/domain/Commit.java
@@ -1,51 +1,84 @@
 package com.tally.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 
 import java.util.List;
 
-@Getter
-@Setter
+@Data
 public class Commit {
     private String sha;
 
-    @JsonProperty("commit")
+    @JsonProperty("node_id")
+    private String nodeId;
+
     private CommitDetail commit;
 
-    private User author;
-    private User committer;
+    private String url;
 
-    // 파일 정보 추가
+    @JsonProperty("html_url")
+    private String htmlUrl;
+
+    private CommitAuthor author;
+
+    private CommitAuthor committer;
+
     private List<CommitFile> files;
 
-    @Getter
-    @Setter
+    @Data
     public static class CommitDetail {
-        private Author author;
-        private Author committer;
+        private GitUser author;
+        private GitUser committer;
         private String message;
 
-        @Getter
-        @Setter
-        public static class Author {
-            private String name;
-            private String email;
-            private String date;
-        }
+        @JsonProperty("comment_count")
+        private Integer commentCount;
     }
 
-    @Getter
-    @Setter
+    @Data
+    public static class GitUser {
+        private String name;
+        private String email;
+        private String date;
+    }
+
+    @Data
+    public static class CommitAuthor {
+        private String login;
+        private Long id;
+
+        @JsonProperty("node_id")
+        private String nodeId;
+
+        @JsonProperty("avatar_url")
+        private String avatarUrl;
+
+        private String url;
+
+        @JsonProperty("html_url")
+        private String htmlUrl;
+
+        private String type;
+    }
+
+    @Data
     public static class CommitFile {
+        private String sha;
         private String filename;
-        private String status;  // added, modified, removed
-        private int additions;
-        private int deletions;
-        private int changes;
+        private String status;
+        private Integer additions;
+        private Integer deletions;
+        private Integer changes;
 
         @JsonProperty("blob_url")
         private String blobUrl;
+
+        @JsonProperty("raw_url")
+        private String rawUrl;
+
+        @JsonProperty("contents_url")
+        private String contentsUrl;
+
+        private String patch;
     }
 }

--- a/src/main/java/com/tally/domain/GitHubRepository.java
+++ b/src/main/java/com/tally/domain/GitHubRepository.java
@@ -3,6 +3,8 @@ package com.tally.domain;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
+import java.util.Objects;
+
 @Data
 public class GitHubRepository {
     private Long id;
@@ -20,7 +22,7 @@ public class GitHubRepository {
     @JsonProperty("html_url")
     private String url;
 
-    private Owner owner;  // String에서 Owner 객체로 변경!
+    private Owner owner;
 
     @JsonProperty("default_branch")
     private String defaultBranch;
@@ -31,18 +33,54 @@ public class GitHubRepository {
     @JsonProperty("updated_at")
     private String updatedAt;
 
-    // Owner 내부 클래스 추가
+    // ✅ Fork 정보 추가
+    private Boolean fork;
+
+    @JsonProperty("parent")
+    private ParentRepository parent;
+
+    // Owner 내부 클래스
     @Data
     public static class Owner {
-        private String login;  // 실제 username
+        private String login;
         private Long id;
 
         @JsonProperty("avatar_url")
         private String avatarUrl;
+
+        private String type;  // "User" 또는 "Organization"
+    }
+
+    // ✅ Parent Repository 내부 클래스 추가
+    @Data
+    public static class ParentRepository {
+        private String name;
+
+        @JsonProperty("full_name")
+        private String fullName;
+
+        private Owner owner;
+
+        @JsonProperty("html_url")
+        private String url;
     }
 
     // 프론트엔드 호환성을 위한 헬퍼 메서드
     public String getOwnerLogin() {
         return owner != null ? owner.getLogin() : null;
+    }
+
+    // 중복 제거를 위한 equals/hashCode (id 기준)
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GitHubRepository that = (GitHubRepository) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/com/tally/domain/Organization.java
+++ b/src/main/java/com/tally/domain/Organization.java
@@ -1,0 +1,30 @@
+package com.tally.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class Organization {
+    private Long id;
+
+    private String login;
+
+    @JsonProperty("avatar_url")
+    private String avatarUrl;
+
+    private String description;
+
+    @JsonProperty("node_id")
+    private String nodeId;
+
+    private String url;
+
+    @JsonProperty("html_url")
+    private String htmlUrl;
+
+    @JsonProperty("repos_url")
+    private String reposUrl;
+
+    @JsonProperty("public_repos")
+    private Integer publicRepos;
+}

--- a/src/main/java/com/tally/domain/OrganizationStats.java
+++ b/src/main/java/com/tally/domain/OrganizationStats.java
@@ -1,0 +1,46 @@
+package com.tally.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrganizationStats {
+    private String organizationName;
+    private String avatarUrl;
+    private String description;
+
+    // 전체 통계
+    private int totalRepositories;
+    private int totalCommits;
+    private int userCommits;
+    private double contributionPercentage;
+
+    // 레포지토리별 상세
+    private List<RepositoryContribution> repositories;
+
+    // 활동 통계
+    private int totalIssues;
+    private int totalPullRequests;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RepositoryContribution {
+        private String name;
+        private String fullName;
+        private String url;
+        private int totalCommits;
+        private int userCommits;
+        private double contributionPercentage;
+        private String lastUpdated;
+    }
+}

--- a/src/main/java/com/tally/service/GitHubService.java
+++ b/src/main/java/com/tally/service/GitHubService.java
@@ -1,9 +1,6 @@
 package com.tally.service;
 
-import com.tally.domain.Commit;
-import com.tally.domain.GitHubRepository;
-import com.tally.domain.Issue;
-import com.tally.domain.PullRequest;
+import com.tally.domain.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -12,9 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -22,7 +18,7 @@ public class GitHubService {
     private final RestTemplate restTemplate = new RestTemplate();
 
     /**
-     * 사용자의 레포지토리 목록 조회
+     * 사용자의 개인 레포지토리 목록 조회 (조직 레포 포함)
      */
     public List<GitHubRepository> getUserRepositories(String token) {
         HttpHeaders headers = new HttpHeaders();
@@ -32,7 +28,7 @@ public class GitHubService {
         HttpEntity<String> request = new HttpEntity<>(headers);
 
         ResponseEntity<GitHubRepository[]> response = restTemplate.exchange(
-                "https://api.github.com/user/repos?per_page=100",
+                "https://api.github.com/user/repos?affiliation=owner,collaborator,organization_member&per_page=100&sort=updated",
                 HttpMethod.GET,
                 request,
                 GitHubRepository[].class
@@ -43,6 +39,177 @@ public class GitHubService {
         }
 
         return new ArrayList<>();
+    }
+
+    /**
+     * 사용자가 속한 조직 목록 조회
+     */
+    public List<Organization> getUserOrganizations(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "token " + token);
+        headers.set("Accept", "application/json");
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<Organization[]> response = restTemplate.exchange(
+                    "https://api.github.com/user/orgs?per_page=100",
+                    HttpMethod.GET,
+                    request,
+                    Organization[].class
+            );
+
+            if (response.getBody() != null) {
+                log.info("Found {} organizations from API", response.getBody().length);
+                return Arrays.asList(response.getBody());
+            }
+        } catch (Exception e) {
+            log.error("Failed to fetch user organizations", e);
+        }
+
+        return new ArrayList<>();
+    }
+
+    /**
+     * 레포지토리 owner 정보에서 조직 목록 추출
+     * (API /user/orgs가 제대로 작동하지 않을 때 대안)
+     */
+    public List<Organization> getOrganizationsFromRepositories(String token) {
+        List<GitHubRepository> repos = getUserRepositories(token);
+        Map<String, Organization> orgMap = new HashMap<>();
+
+        for (GitHubRepository repo : repos) {
+            // 조직 소유 레포
+            if (repo.getOwner() != null && "Organization".equals(repo.getOwner().getType())) {
+                String orgLogin = repo.getOwner().getLogin();
+
+                if (!orgMap.containsKey(orgLogin)) {
+                    Organization org = new Organization();
+                    org.setId(repo.getOwner().getId());
+                    org.setLogin(orgLogin);
+                    org.setAvatarUrl(repo.getOwner().getAvatarUrl());
+                    org.setDescription("조직 레포지토리");
+                    orgMap.put(orgLogin, org);
+                }
+            }
+
+            // Fork의 원본이 조직인 경우
+            if (repo.getFork() != null && repo.getFork() &&
+                    repo.getParent() != null &&
+                    repo.getParent().getOwner() != null &&
+                    "Organization".equals(repo.getParent().getOwner().getType())) {
+
+                String orgLogin = repo.getParent().getOwner().getLogin();
+
+                if (!orgMap.containsKey(orgLogin)) {
+                    Organization org = new Organization();
+                    org.setId(repo.getParent().getOwner().getId());
+                    org.setLogin(orgLogin);
+                    org.setAvatarUrl(repo.getParent().getOwner().getAvatarUrl());
+                    org.setDescription("Fork된 레포지토리 원본 조직");
+                    orgMap.put(orgLogin, org);
+                }
+            }
+        }
+
+        List<Organization> organizations = new ArrayList<>(orgMap.values());
+        log.info("Extracted {} organizations from repositories", organizations.size());
+        return organizations;
+    }
+
+    /**
+     * 특정 조직의 레포지토리 목록 조회
+     */
+    public List<GitHubRepository> getOrganizationRepositories(String token, String org) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "token " + token);
+        headers.set("Accept", "application/json");
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<GitHubRepository[]> response = restTemplate.exchange(
+                    String.format("https://api.github.com/orgs/%s/repos?per_page=100&sort=updated", org),
+                    HttpMethod.GET,
+                    request,
+                    GitHubRepository[].class
+            );
+
+            if (response.getBody() != null) {
+                log.info("Found {} repositories in organization {}", response.getBody().length, org);
+                return Arrays.asList(response.getBody());
+            }
+        } catch (Exception e) {
+            log.error("Failed to fetch repositories for organization: {}", org, e);
+        }
+
+        return new ArrayList<>();
+    }
+
+    /**
+     * 사용자의 모든 레포지토리 조회 (개인 + 조직의 모든 레포)
+     */
+    public List<GitHubRepository> getAllRepositories(String token) {
+        List<GitHubRepository> allRepos = new ArrayList<>();
+
+        // 1. 개인 레포 + 직접 기여한 레포
+        log.info("Fetching user repositories...");
+        List<GitHubRepository> userRepos = getUserRepositories(token);
+        allRepos.addAll(userRepos);
+        log.info("Found {} user repositories", userRepos.size());
+
+        // 2. 속한 조직의 모든 레포
+        log.info("Fetching organizations...");
+        List<Organization> orgs = getUserOrganizations(token);
+
+        for (Organization org : orgs) {
+            log.info("Fetching repositories for organization: {}", org.getLogin());
+            List<GitHubRepository> orgRepos = getOrganizationRepositories(token, org.getLogin());
+            allRepos.addAll(orgRepos);
+        }
+
+        // 3. 중복 제거 (같은 레포가 여러 번 나올 수 있음)
+        List<GitHubRepository> uniqueRepos = allRepos.stream()
+                .distinct()
+                .collect(Collectors.toList());
+
+        log.info("Total repositories after deduplication: {}", uniqueRepos.size());
+        return uniqueRepos;
+    }
+
+    /**
+     * 특정 조직에서 사용자가 기여한 레포지토리만 필터링
+     */
+    public List<GitHubRepository> getUserRepositoriesInOrganization(String token, String orgName, String username) {
+        List<GitHubRepository> orgRepos = getOrganizationRepositories(token, orgName);
+        List<GitHubRepository> contributedRepos = new ArrayList<>();
+
+        for (GitHubRepository repo : orgRepos) {
+            // 각 레포의 커밋을 확인하여 사용자가 기여했는지 체크
+            List<Commit> commits = getRepositoryCommits(token, orgName, repo.getName());
+
+            boolean hasContribution = commits.stream()
+                    .anyMatch(commit -> {
+                        // author가 있고 login이 일치하는지 확인
+                        if (commit.getAuthor() != null && commit.getAuthor().getLogin() != null) {
+                            return username.equalsIgnoreCase(commit.getAuthor().getLogin());
+                        }
+                        // commit.commit.author의 이름으로도 확인
+                        if (commit.getCommit() != null && commit.getCommit().getAuthor() != null) {
+                            String authorName = commit.getCommit().getAuthor().getName();
+                            return authorName != null && authorName.equalsIgnoreCase(username);
+                        }
+                        return false;
+                    });
+
+            if (hasContribution) {
+                contributedRepos.add(repo);
+            }
+        }
+
+        log.info("User {} contributed to {}/{} repositories in organization {}",
+                username, contributedRepos.size(), orgRepos.size(), orgName);
+        return contributedRepos;
     }
 
     /**
@@ -57,15 +224,19 @@ public class GitHubService {
 
         String url = String.format("https://api.github.com/repos/%s/%s/commits?per_page=100", owner, repo);
 
-        ResponseEntity<Commit[]> response = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                request,
-                Commit[].class
-        );
+        try {
+            ResponseEntity<Commit[]> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    request,
+                    Commit[].class
+            );
 
-        if (response.getBody() != null) {
-            return Arrays.asList(response.getBody());
+            if (response.getBody() != null) {
+                return Arrays.asList(response.getBody());
+            }
+        } catch (Exception e) {
+            log.error("Failed to fetch commits for {}/{}: {}", owner, repo, e.getMessage());
         }
 
         return new ArrayList<>();
@@ -110,15 +281,19 @@ public class GitHubService {
 
         String url = String.format("https://api.github.com/repos/%s/%s/pulls?state=all&per_page=100", owner, repo);
 
-        ResponseEntity<PullRequest[]> response = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                request,
-                PullRequest[].class
-        );
+        try {
+            ResponseEntity<PullRequest[]> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    request,
+                    PullRequest[].class
+            );
 
-        if (response.getBody() != null) {
-            return Arrays.asList(response.getBody());
+            if (response.getBody() != null) {
+                return Arrays.asList(response.getBody());
+            }
+        } catch (Exception e) {
+            log.error("Failed to fetch pull requests for {}/{}: {}", owner, repo, e.getMessage());
         }
 
         return new ArrayList<>();
@@ -136,15 +311,19 @@ public class GitHubService {
 
         String url = String.format("https://api.github.com/repos/%s/%s/issues?state=all&per_page=100", owner, repo);
 
-        ResponseEntity<Issue[]> response = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                request,
-                Issue[].class
-        );
+        try {
+            ResponseEntity<Issue[]> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    request,
+                    Issue[].class
+            );
 
-        if (response.getBody() != null) {
-            return Arrays.asList(response.getBody());
+            if (response.getBody() != null) {
+                return Arrays.asList(response.getBody());
+            }
+        } catch (Exception e) {
+            log.error("Failed to fetch issues for {}/{}: {}", owner, repo, e.getMessage());
         }
 
         return new ArrayList<>();

--- a/src/main/java/com/tally/util/JsonFileUtil.java
+++ b/src/main/java/com/tally/util/JsonFileUtil.java
@@ -2,7 +2,7 @@ package com.tally.util;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
@@ -11,78 +11,142 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
 public class JsonFileUtil {
+
     private static final ObjectMapper objectMapper = new ObjectMapper()
-            .registerModule(new JavaTimeModule());
+            .enable(SerializationFeature.INDENT_OUTPUT);
 
-    private static final String DATA_DIR = "data";
-
-    static {
+    /**
+     * 데이터를 JSON 파일로 저장 (단일 객체 또는 리스트)
+     */
+    public static <T> void writeToFile(String filePath, T data) {
         try {
-            Files.createDirectories(Paths.get(DATA_DIR));
-        } catch (IOException e) {
-            log.error("Failed to create data directory", e);
-        }
-    }
+            // 디렉토리가 없으면 생성
+            Path path = Paths.get(filePath);
+            if (path.getParent() != null) {
+                Files.createDirectories(path.getParent());
+            }
 
-    public static <T> void writeToFile(String fileName, T data) {
-        try {
-            Path filePath = Paths.get(DATA_DIR, fileName);
-            objectMapper.writerWithDefaultPrettyPrinter().writeValue(filePath.toFile(), data);
+            // JSON 파일로 저장
+            objectMapper.writeValue(new File(filePath), data);
             log.debug("Saved data to file: {}", filePath);
+
         } catch (IOException e) {
-            log.error("Failed to write to file: {}", fileName, e);
-            throw new RuntimeException("Failed to write to file: " + fileName, e);
+            log.error("Failed to save data to file: {}", filePath, e);
+            throw new RuntimeException("Failed to save data to file", e);
         }
     }
 
-    public static <T> T readFromFile(String fileName, Class<T> clazz) {
+    /**
+     * JSON 파일에서 단일 객체 로드
+     */
+    public static <T> T readFromFile(String filePath, Class<T> clazz) {
         try {
-            Path filePath = Paths.get(DATA_DIR, fileName);
-            File file = filePath.toFile();
+            File file = new File(filePath);
 
             if (!file.exists()) {
+                log.warn("File does not exist: {}", filePath);
                 return null;
             }
 
             return objectMapper.readValue(file, clazz);
+
         } catch (IOException e) {
-            log.error("Failed to read from file: {}", fileName, e);
+            log.error("Failed to load data from file: {}", filePath, e);
             return null;
         }
     }
 
-
-    public static <T> List<T> readFromFile(String fileName, TypeReference<List<T>> typeReference) {
+    /**
+     * JSON 파일에서 데이터 로드 (TypeReference 사용)
+     * 주로 List, Map 등 제네릭 타입에 사용
+     */
+    public static <T> T readFromFile(String filePath, TypeReference<T> typeReference) {
         try {
-            Path filePath = Paths.get(DATA_DIR, fileName);
-            File file = filePath.toFile();
+            File file = new File(filePath);
 
             if (!file.exists()) {
-                return new ArrayList<>();
+                log.warn("File does not exist: {}, returning empty list", filePath);
+                // 파일이 없으면 빈 리스트 반환 (List<T>인 경우)
+                return objectMapper.readValue("[]", typeReference);
             }
 
             return objectMapper.readValue(file, typeReference);
+
         } catch (IOException e) {
-            log.error("Failed to read from file: {}", fileName, e);
+            log.error("Failed to load data from file: {}", filePath, e);
+            try {
+                // 에러 발생 시 빈 리스트 반환
+                return objectMapper.readValue("[]", typeReference);
+            } catch (IOException ex) {
+                throw new RuntimeException("Failed to load data from file", e);
+            }
+        }
+    }
+
+    /**
+     * 데이터를 JSON 파일로 저장 (리스트)
+     */
+    public static <T> void saveToFile(String filePath, T data) {
+        writeToFile(filePath, data);
+    }
+
+    /**
+     * JSON 파일에서 리스트 데이터 로드
+     */
+    public static <T> List<T> loadFromFile(String filePath, Class<T[]> clazz) {
+        try {
+            File file = new File(filePath);
+
+            if (!file.exists()) {
+                log.warn("File does not exist: {}", filePath);
+                return new ArrayList<>();
+            }
+
+            T[] array = objectMapper.readValue(file, clazz);
+            return new ArrayList<>(Arrays.asList(array));
+
+        } catch (IOException e) {
+            log.error("Failed to load data from file: {}", filePath, e);
             return new ArrayList<>();
         }
     }
 
-    public static void deleteFile(String fileName) {
-        try {
-            Path filePath = Paths.get(DATA_DIR, fileName);
-            Files.deleteIfExists(filePath);
-            log.debug("Deleted file: {}", filePath);
-        } catch (IOException e) {
-            log.error("Failed to delete file: {}", fileName, e);
-        }
+    /**
+     * 단일 객체를 JSON 파일에서 로드
+     */
+    public static <T> T loadSingleFromFile(String filePath, Class<T> clazz) {
+        return readFromFile(filePath, clazz);
     }
 
-    public static boolean fileExists(String fileName) {
-        return Files.exists(Paths.get(DATA_DIR, fileName));
+    /**
+     * 파일 존재 여부 확인
+     */
+    public static boolean fileExists(String filePath) {
+        return new File(filePath).exists();
+    }
+
+    /**
+     * 파일 삭제
+     */
+    public static boolean deleteFile(String filePath) {
+        try {
+            File file = new File(filePath);
+            if (file.exists()) {
+                boolean deleted = file.delete();
+                if (deleted) {
+                    log.debug("Deleted file: {}", filePath);
+                }
+                return deleted;
+            }
+            return false;
+        } catch (Exception e) {
+            log.error("Failed to delete file: {}", filePath, e);
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## 변경 사항

조직 레포지토리 지원 기능 추가

Closes #이슈번호

### 이슈 해결
- ✅ `getUserRepositories()`에 `affiliation=owner,collaborator,organization_member` 파라미터 추가
- ✅ 조직 레포지토리가 대시보드에 정상 표시됨

### 추가 구현
- Organization API 엔드포인트 (`/organizations`, `/organizations/{orgName}/stats`)
- OAuth `read:org` 스코프 추가
- 조직별 기여도 통계 분석
- GET `/analysis/{owner}/{repo}` 엔드포인트

### 새로운 파일
- `Organization.java`, `OrganizationStats.java`
- `OrganizationController.java`
- `AuthService.java`, `JsonFileUtil.java`

### API 엔드포인트
```
GET /organizations
GET /organizations/{orgName}/stats
GET /organizations/{orgName}/repositories
GET /analysis/{owner}/{repo}?username={username}
```

### 테스트 결과
- ✅ 조직 레포 44개 정상 표시 (개인 + 조직)
- ✅ 조직 목록 13개 정상 조회
- ✅ 조직 통계 분석 정상 작동
- ✅ OAuth 권한 승인 플로우 정상

### 알려진 이슈
- 분석 시간 30-60초 소요 (다음 PR에서 최적화 예정)