### PR TITLE
feat: MCP Server GitHub 분석 도구 구현

### DIFF
--- a/tally-agent/src/main/resources/application.yml
+++ b/tally-agent/src/main/resources/application.yml
@@ -10,6 +10,11 @@ spring:
           max-tokens: 4096
     mcp:
       client:
+        enabled: true
+        name: tally-agent
+        version: 3.0.0
+        request-timeout: 30s
+        type: SYNC
         sse:
           connections:
             github-mcp:
@@ -21,3 +26,4 @@ server:
 logging:
   level:
     com.devpulse: DEBUG
+    org.springframework.ai: DEBUG

--- a/tally-mcp-github/src/main/java/com/devpulse/mcp/github/service/ContributionAnalysisService.java
+++ b/tally-mcp-github/src/main/java/com/devpulse/mcp/github/service/ContributionAnalysisService.java
@@ -1,0 +1,217 @@
+package com.devpulse.mcp.github.service;
+
+import com.devpulse.mcp.github.domain.*;
+import com.devpulse.mcp.github.service.GraphQLGitHubService.RepositoryData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * GraphQL 기반 기여도 분석 서비스 (REST 의존 제거)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ContributionAnalysisService {
+
+    private final GraphQLGitHubService graphQLService;
+
+    /**
+     * 레포지토리 기여도 분석 (GraphQL 1회 호출)
+     */
+    public ContributionStats analyzeContribution(String token, String owner, String repo, String username) {
+        log.info("Analyzing contribution for {} in {}/{}", username, owner, repo);
+
+        RepositoryData repoData = graphQLService.getRepositoryAnalysis(token, owner, repo);
+
+        // 커밋 필터링
+        List<Commit> allCommits = repoData.getCommits();
+        List<Commit> userCommits = allCommits.stream()
+                .filter(c -> isCommitByUser(c, username))
+                .collect(Collectors.toList());
+
+        // PR 필터링
+        List<PullRequest> userPRs = repoData.getPullRequests().stream()
+                .filter(pr -> pr.getUser() != null && username.equalsIgnoreCase(pr.getUser().getLogin()))
+                .collect(Collectors.toList());
+
+        // Issue 필터링
+        List<Issue> userIssues = repoData.getIssues().stream()
+                .filter(issue -> issue.getUser() != null && username.equalsIgnoreCase(issue.getUser().getLogin()))
+                .collect(Collectors.toList());
+
+        // 활동 기간
+        String firstCommitDate = null;
+        String lastCommitDate = null;
+        if (!userCommits.isEmpty()) {
+            List<String> dates = userCommits.stream()
+                    .filter(c -> c.getCommit() != null && c.getCommit().getAuthor() != null
+                            && c.getCommit().getAuthor().getDate() != null)
+                    .map(c -> c.getCommit().getAuthor().getDate().substring(0, 10))
+                    .sorted()
+                    .collect(Collectors.toList());
+            if (!dates.isEmpty()) {
+                firstCommitDate = dates.get(0);
+                lastCommitDate = dates.get(dates.size() - 1);
+            }
+        }
+
+        double commitPercentage = allCommits.isEmpty() ? 0.0
+                : (double) userCommits.size() / allCommits.size() * 100;
+
+        // 커밋 메시지 (AI 분석용, 최근 30개)
+        List<String> commitMessages = userCommits.stream()
+                .filter(c -> c.getCommit() != null && c.getCommit().getMessage() != null)
+                .map(c -> c.getCommit().getMessage().split("\n")[0])
+                .limit(30)
+                .collect(Collectors.toList());
+
+        // 역할 분석 (커밋 메시지 기반 — 파일 경로 없이도 가능)
+        Map<String, ContributionStats.RoleStats> roleDistribution = analyzeRolesFromMessages(commitMessages);
+
+        ContributionStats stats = ContributionStats.builder()
+                .id(UUID.randomUUID().toString())
+                .userId(username)
+                .username(username)
+                .repositoryFullName(owner + "/" + repo)
+                .firstCommitDate(firstCommitDate)
+                .lastCommitDate(lastCommitDate)
+                .totalCommits(repoData.getTotalCommitCount())
+                .userCommits(userCommits.size())
+                .commitPercentage(commitPercentage)
+                .languageDistribution(repoData.getLanguageDistribution())
+                .roleDistribution(roleDistribution)
+                .pullRequests(userPRs)
+                .issues(userIssues)
+                .commitMessages(commitMessages)
+                .analyzedAt(LocalDateTime.now())
+                .build();
+
+        log.info("Analysis complete: {}/{} — User: {}, Commits: {}/{} ({}%), PRs: {}, Issues: {}",
+                owner, repo, username, userCommits.size(), allCommits.size(),
+                String.format("%.1f", commitPercentage), userPRs.size(), userIssues.size());
+
+        return stats;
+    }
+
+    /**
+     * 조직 전체 분석
+     */
+    public OrganizationStats analyzeOrganization(String token, String orgName, String username) {
+        log.info("Analyzing organization {} for user {}", orgName, username);
+
+        Map<String, RepositoryData> repoDataMap = graphQLService.getOrganizationFullAnalysis(token, orgName);
+
+        int[] totalCommits = {0};
+        int[] userCommitsTotal = {0};
+        List<OrganizationStats.RepositoryContribution> repoContributions = new ArrayList<>();
+        Map<String, Integer> teamCommitCounts = new HashMap<>();
+
+        for (Map.Entry<String, RepositoryData> entry : repoDataMap.entrySet()) {
+            RepositoryData data = entry.getValue();
+            List<Commit> commits = data.getCommits();
+            int repoTotal = commits.size();
+            totalCommits[0] += repoTotal;
+
+            for (Commit commit : commits) {
+                String author = getCommitAuthorLogin(commit);
+                if (author != null) {
+                    teamCommitCounts.merge(author, 1, Integer::sum);
+                }
+            }
+
+            long userRepoCommits = commits.stream().filter(c -> isCommitByUser(c, username)).count();
+            userCommitsTotal[0] += (int) userRepoCommits;
+
+            double percentage = repoTotal == 0 ? 0.0 : (double) userRepoCommits / repoTotal * 100;
+
+            repoContributions.add(OrganizationStats.RepositoryContribution.builder()
+                    .name(data.getName())
+                    .fullName(data.getFullName())
+                    .url(data.getUrl())
+                    .totalCommits(repoTotal)
+                    .userCommits((int) userRepoCommits)
+                    .contributionPercentage(percentage)
+                    .build());
+        }
+
+        final int finalTotalCommits = totalCommits[0];
+        List<OrganizationStats.TeamMember> teamMembers = teamCommitCounts.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .map(e -> OrganizationStats.TeamMember.builder()
+                        .login(e.getKey())
+                        .commits(e.getValue())
+                        .contributionPercentage(finalTotalCommits == 0 ? 0 : (double) e.getValue() / finalTotalCommits * 100)
+                        .build())
+                .collect(Collectors.toList());
+
+        return OrganizationStats.builder()
+                .organizationName(orgName)
+                .totalRepositories(repoDataMap.size())
+                .totalCommits(finalTotalCommits)
+                .userCommits(userCommitsTotal[0])
+                .contributionPercentage(finalTotalCommits == 0 ? 0 : (double) userCommitsTotal[0] / finalTotalCommits * 100)
+                .repositories(repoContributions)
+                .teamMembers(teamMembers)
+                .build();
+    }
+
+    private boolean isCommitByUser(Commit commit, String username) {
+        // GitHub login으로 먼저 체크
+        if (commit.getAuthor() != null && commit.getAuthor().getLogin() != null) {
+            return username.equalsIgnoreCase(commit.getAuthor().getLogin());
+        }
+        // Git author name으로 폴백
+        if (commit.getCommit() != null && commit.getCommit().getAuthor() != null) {
+            String name = commit.getCommit().getAuthor().getName();
+            return name != null && username.equalsIgnoreCase(name);
+        }
+        return false;
+    }
+
+    private String getCommitAuthorLogin(Commit commit) {
+        if (commit.getAuthor() != null && commit.getAuthor().getLogin() != null) {
+            return commit.getAuthor().getLogin();
+        }
+        if (commit.getCommit() != null && commit.getCommit().getAuthor() != null) {
+            return commit.getCommit().getAuthor().getName();
+        }
+        return null;
+    }
+
+    /**
+     * 커밋 메시지 기반 역할 분석 (Conventional Commits)
+     */
+    private Map<String, ContributionStats.RoleStats> analyzeRolesFromMessages(List<String> messages) {
+        Map<String, Integer> roleCounts = new HashMap<>();
+
+        for (String msg : messages) {
+            String lower = msg.toLowerCase();
+            if (lower.startsWith("feat")) roleCounts.merge("feature", 1, Integer::sum);
+            else if (lower.startsWith("fix")) roleCounts.merge("bugfix", 1, Integer::sum);
+            else if (lower.startsWith("docs")) roleCounts.merge("documentation", 1, Integer::sum);
+            else if (lower.startsWith("test")) roleCounts.merge("test", 1, Integer::sum);
+            else if (lower.startsWith("refactor")) roleCounts.merge("refactoring", 1, Integer::sum);
+            else if (lower.startsWith("chore") || lower.startsWith("ci") || lower.startsWith("build"))
+                roleCounts.merge("infrastructure", 1, Integer::sum);
+            else if (lower.startsWith("style")) roleCounts.merge("style", 1, Integer::sum);
+            else if (lower.startsWith("perf")) roleCounts.merge("performance", 1, Integer::sum);
+            else roleCounts.merge("other", 1, Integer::sum);
+        }
+
+        int total = messages.size();
+        Map<String, ContributionStats.RoleStats> result = new HashMap<>();
+        for (Map.Entry<String, Integer> entry : roleCounts.entrySet()) {
+            result.put(entry.getKey(), ContributionStats.RoleStats.builder()
+                    .roleName(entry.getKey())
+                    .commitCount(entry.getValue())
+                    .percentage(total == 0 ? 0 : (double) entry.getValue() / total * 100)
+                    .build());
+        }
+        return result;
+    }
+}

--- a/tally-mcp-github/src/main/java/com/devpulse/mcp/github/tools/RepoAnalysisTools.java
+++ b/tally-mcp-github/src/main/java/com/devpulse/mcp/github/tools/RepoAnalysisTools.java
@@ -1,0 +1,225 @@
+package com.devpulse.mcp.github.tools;
+
+import com.devpulse.mcp.github.domain.*;
+import com.devpulse.mcp.github.service.ContributionAnalysisService;
+import com.devpulse.mcp.github.service.GraphQLGitHubService;
+import com.devpulse.mcp.github.service.QualityAnalysisService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * MCP Server 도구 — 레포지토리 분석
+ * tally-agent의 MCP Client가 이 도구들을 호출합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RepoAnalysisTools {
+
+    private final GraphQLGitHubService graphQLService;
+    private final ContributionAnalysisService contributionService;
+    private final QualityAnalysisService qualityService;
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Tool(description = "사용자의 GitHub 레포지토리 목록을 조회합니다. 레포 이름, 소유자, 설명, public/private 여부를 반환합니다.")
+    public String listRepos(
+            @ToolParam(description = "GitHub 액세스 토큰") String token) {
+        log.info("Tool: list_repos");
+        List<GitHubRepository> repos = graphQLService.getUserRepositories(token);
+
+        return repos.stream()
+                .map(r -> String.format("- %s (%s) %s",
+                        r.getFullName(),
+                        r.getIsPrivate() ? "private" : "public",
+                        r.getDescription() != null ? r.getDescription() : ""))
+                .collect(Collectors.joining("\n"));
+    }
+
+    @Tool(description = "특정 레포지토리의 기여도를 분석합니다. 커밋 수, 기여 비율, PR, Issue, 역할 분석 결과를 반환합니다.")
+    public String analyzeRepo(
+            @ToolParam(description = "GitHub 액세스 토큰") String token,
+            @ToolParam(description = "레포지토리 소유자 (예: Tally-lab)") String owner,
+            @ToolParam(description = "레포지토리 이름 (예: Tally-BE)") String repo,
+            @ToolParam(description = "분석 대상 GitHub 사용자명") String username) {
+        log.info("Tool: analyze_repo {}/{} for {}", owner, repo, username);
+        ContributionStats stats = contributionService.analyzeContribution(token, owner, repo, username);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("## %s/%s 기여도 분석 — %s\n\n", owner, repo, username));
+        sb.append(String.format("- 총 커밋: %d개\n", stats.getTotalCommits()));
+        sb.append(String.format("- 내 커밋: %d개 (%.1f%%)\n", stats.getUserCommits(), stats.getCommitPercentage()));
+        sb.append(String.format("- 활동 기간: %s ~ %s\n", stats.getFirstCommitDate(), stats.getLastCommitDate()));
+        sb.append(String.format("- PR: %d개\n", stats.getPullRequests() != null ? stats.getPullRequests().size() : 0));
+        sb.append(String.format("- Issue: %d개\n", stats.getIssues() != null ? stats.getIssues().size() : 0));
+
+        if (stats.getRoleDistribution() != null && !stats.getRoleDistribution().isEmpty()) {
+            sb.append("\n### 역할 분포\n");
+            stats.getRoleDistribution().entrySet().stream()
+                    .sorted((a, b) -> Double.compare(b.getValue().getPercentage(), a.getValue().getPercentage()))
+                    .forEach(e -> sb.append(String.format("- %s: %.1f%% (%d커밋)\n",
+                            e.getKey(), e.getValue().getPercentage(), e.getValue().getCommitCount())));
+        }
+
+        if (stats.getLanguageDistribution() != null && !stats.getLanguageDistribution().isEmpty()) {
+            sb.append("\n### 언어 분포\n");
+            stats.getLanguageDistribution().entrySet().stream()
+                    .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                    .limit(5)
+                    .forEach(e -> sb.append(String.format("- %s: %,d bytes\n", e.getKey(), e.getValue())));
+        }
+
+        return sb.toString();
+    }
+
+    @Tool(description = "레포지토리의 커밋 품질을 분석합니다. Conventional Commits 준수율, 커밋 타입 분포, 품질 등급(A-F)을 반환합니다.")
+    public String getCommitQuality(
+            @ToolParam(description = "GitHub 액세스 토큰") String token,
+            @ToolParam(description = "레포지토리 소유자") String owner,
+            @ToolParam(description = "레포지토리 이름") String repo) {
+        log.info("Tool: get_commit_quality {}/{}", owner, repo);
+
+        GraphQLGitHubService.RepositoryData repoData = graphQLService.getRepositoryAnalysis(token, owner, repo);
+        CommitQualityMetrics metrics = qualityService.analyzeCommitQuality(repoData.getCommits());
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("## %s/%s 커밋 품질 분석\n\n", owner, repo));
+        sb.append(String.format("- 품질 등급: **%s**\n", metrics.getQualityGrade()));
+        sb.append(String.format("- 총 커밋: %d개\n", metrics.getTotalCommits()));
+        sb.append(String.format("- Conventional Commits 준수: %d/%d (%.1f%%)\n",
+                metrics.getConventionalCommits(), metrics.getTotalCommits(), metrics.getConventionalCommitRate()));
+
+        if (metrics.getCommitTypeDistribution() != null && !metrics.getCommitTypeDistribution().isEmpty()) {
+            sb.append("\n### 커밋 타입 분포\n");
+            metrics.getCommitTypeDistribution().entrySet().stream()
+                    .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                    .forEach(e -> sb.append(String.format("- %s: %d개\n", e.getKey(), e.getValue())));
+        }
+
+        return sb.toString();
+    }
+
+    @Tool(description = "레포지토리의 PR 품질을 분석합니다. 머지율, 평균 리뷰 시간, 품질 등급(A-F)을 반환합니다.")
+    public String getPrQuality(
+            @ToolParam(description = "GitHub 액세스 토큰") String token,
+            @ToolParam(description = "레포지토리 소유자") String owner,
+            @ToolParam(description = "레포지토리 이름") String repo) {
+        log.info("Tool: get_pr_quality {}/{}", owner, repo);
+
+        GraphQLGitHubService.RepositoryData repoData = graphQLService.getRepositoryAnalysis(token, owner, repo);
+        PRQualityMetrics metrics = qualityService.analyzePRQuality(repoData.getPullRequests());
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("## %s/%s PR 품질 분석\n\n", owner, repo));
+        sb.append(String.format("- 품질 등급: **%s**\n", metrics.getQualityGrade()));
+        sb.append(String.format("- 총 PR: %d개\n", metrics.getTotalPRs()));
+        sb.append(String.format("- 머지율: %.1f%% (%d merged / %d closed / %d open)\n",
+                metrics.getMergeRate(), metrics.getMergedPRs(),
+                metrics.getClosedWithoutMergePRs(), metrics.getOpenPRs()));
+        sb.append(String.format("- 평균 리뷰 시간: %.1f시간\n", metrics.getAverageReviewTimeHours()));
+
+        return sb.toString();
+    }
+
+    @Tool(description = "조직(Organization)의 전체 레포지토리 기여도를 분석합니다. 팀원별 기여도, 레포별 통계를 반환합니다.")
+    public String getOrgStats(
+            @ToolParam(description = "GitHub 액세스 토큰") String token,
+            @ToolParam(description = "조직 이름 (예: Tally-lab)") String orgName,
+            @ToolParam(description = "분석 대상 사용자명") String username) {
+        log.info("Tool: get_org_stats {} for {}", orgName, username);
+
+        OrganizationStats stats = contributionService.analyzeOrganization(token, orgName, username);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("## %s 조직 분석 — %s\n\n", orgName, username));
+        sb.append(String.format("- 레포지토리: %d개\n", stats.getTotalRepositories()));
+        sb.append(String.format("- 총 커밋: %d개 / 내 커밋: %d개 (%.1f%%)\n",
+                stats.getTotalCommits(), stats.getUserCommits(), stats.getContributionPercentage()));
+
+        if (stats.getRepositories() != null && !stats.getRepositories().isEmpty()) {
+            sb.append("\n### 레포별 기여도\n");
+            stats.getRepositories().stream()
+                    .sorted((a, b) -> Integer.compare(b.getUserCommits(), a.getUserCommits()))
+                    .forEach(r -> sb.append(String.format("- %s: %d/%d (%.1f%%)\n",
+                            r.getName(), r.getUserCommits(), r.getTotalCommits(), r.getContributionPercentage())));
+        }
+
+        if (stats.getTeamMembers() != null && !stats.getTeamMembers().isEmpty()) {
+            sb.append("\n### 팀원별 기여도 (상위 10명)\n");
+            stats.getTeamMembers().stream().limit(10)
+                    .forEach(m -> sb.append(String.format("- %s: %d커밋 (%.1f%%)\n",
+                            m.getLogin(), m.getCommits(), m.getContributionPercentage())));
+        }
+
+        return sb.toString();
+    }
+
+    @Tool(description = "두 개 이상의 레포지토리를 비교 분석합니다. 각 레포의 기여도, 커밋 품질, PR 품질을 나란히 비교합니다.")
+    public String compareRepos(
+            @ToolParam(description = "GitHub 액세스 토큰") String token,
+            @ToolParam(description = "비교할 레포 목록 (owner/repo 형식, 쉼표 구분)") String repoList,
+            @ToolParam(description = "분석 대상 사용자명") String username) {
+        log.info("Tool: compare_repos [{}] for {}", repoList, username);
+
+        String[] repos = repoList.split(",");
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("## 레포지토리 비교 분석 — %s\n\n", username));
+        sb.append("| 항목 |");
+        for (String r : repos) sb.append(String.format(" %s |", r.trim()));
+        sb.append("\n|------|");
+        for (String ignored : repos) sb.append("------|");
+        sb.append("\n");
+
+        // 각 레포 분석
+        ContributionStats[] statsArr = new ContributionStats[repos.length];
+        CommitQualityMetrics[] commitQArr = new CommitQualityMetrics[repos.length];
+        PRQualityMetrics[] prQArr = new PRQualityMetrics[repos.length];
+
+        for (int i = 0; i < repos.length; i++) {
+            String[] parts = repos[i].trim().split("/");
+            if (parts.length != 2) continue;
+
+            GraphQLGitHubService.RepositoryData repoData = graphQLService.getRepositoryAnalysis(token, parts[0], parts[1]);
+            statsArr[i] = contributionService.analyzeContribution(token, parts[0], parts[1], username);
+            commitQArr[i] = qualityService.analyzeCommitQuality(repoData.getCommits());
+            prQArr[i] = qualityService.analyzePRQuality(repoData.getPullRequests());
+        }
+
+        // 테이블 행 생성
+        sb.append("| 기여도 |");
+        for (ContributionStats s : statsArr) sb.append(s != null ? String.format(" %.1f%% |", s.getCommitPercentage()) : " N/A |");
+        sb.append("\n| 커밋 수 |");
+        for (ContributionStats s : statsArr) sb.append(s != null ? String.format(" %d/%d |", s.getUserCommits(), s.getTotalCommits()) : " N/A |");
+        sb.append("\n| PR 수 |");
+        for (ContributionStats s : statsArr) sb.append(s != null ? String.format(" %d |", s.getPullRequests() != null ? s.getPullRequests().size() : 0) : " N/A |");
+        sb.append("\n| 커밋 품질 |");
+        for (CommitQualityMetrics q : commitQArr) sb.append(q != null ? String.format(" %s (%.0f%%) |", q.getQualityGrade(), q.getConventionalCommitRate()) : " N/A |");
+        sb.append("\n| PR 머지율 |");
+        for (PRQualityMetrics q : prQArr) sb.append(q != null ? String.format(" %.1f%% |", q.getMergeRate()) : " N/A |");
+        sb.append("\n");
+
+        return sb.toString();
+    }
+
+    @Tool(description = "사용자의 조직 목록을 조회합니다.")
+    public String listOrganizations(
+            @ToolParam(description = "GitHub 액세스 토큰") String token) {
+        log.info("Tool: list_organizations");
+        List<Organization> orgs = graphQLService.getUserOrganizations(token);
+
+        if (orgs.isEmpty()) return "소속된 조직이 없습니다.";
+
+        return orgs.stream()
+                .map(o -> String.format("- %s%s", o.getLogin(),
+                        o.getDescription() != null ? " — " + o.getDescription() : ""))
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/tally-mcp-github/src/main/resources/application.yml
+++ b/tally-mcp-github/src/main/resources/application.yml
@@ -6,6 +6,14 @@ spring:
       server:
         name: tally-mcp-github
         version: 3.0.0
+        type: SYNC
+        instructions: >
+          GitHub 레포지토리 분석 도구를 제공하는 MCP Server입니다.
+          레포 목록 조회, 기여도 분석, 커밋/PR 품질 분석, 조직 분석, 레포 비교 기능을 지원합니다.
+          모든 도구는 GitHub 액세스 토큰이 필요합니다.
+        capabilities:
+          tool: true
+        sse-message-endpoint: /mcp/messages
 
 server:
   port: 8081
@@ -13,6 +21,4 @@ server:
 logging:
   level:
     com.devpulse: DEBUG
-
-github:
-  graphql-endpoint: https://api.github.com/graphql
+    org.springframework.ai.mcp: DEBUG


### PR DESCRIPTION
## Summary
- 기존 GitHub 분석 서비스를 Spring AI `@Tool` 어노테이션으로 MCP 도구 전환
- ContributionAnalysisService를 GraphQL 기반으로 완전 리팩토링 (REST 의존 제거)
- MCP Server SSE transport 설정 완료

## MCP 도구 목록 (7개)
| 도구 | 설명 |
|------|------|
| `listRepos` | 사용자 레포 목록 조회 |
| `analyzeRepo` | 레포 기여도 분석 (커밋/PR/Issue/역할) |
| `getCommitQuality` | 커밋 품질 분석 (Conventional Commits 준수율, 등급) |
| `getPrQuality` | PR 품질 분석 (머지율, 리뷰 시간, 등급) |
| `getOrgStats` | 조직 전체 분석 (팀원별 기여도) |
| `compareRepos` | 레포 비교 분석 |
| `listOrganizations` | 사용자 조직 목록 |

## Test plan
- [x] `./gradlew clean build -x test` — BUILD SUCCESSFUL
- [x] tally-mcp-github 서버 기동 확인 (`McpServerAutoConfiguration: Enable tools capabilities`)

Closes #29