### PR TITLE
feat: Spring AI Agent 코어 구현 (#30)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
       - SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_GITHUB-MCP_URL=http://tally-mcp-github:8081
     depends_on:
       - tally-mcp-github

--- a/tally-agent/build.gradle.kts
+++ b/tally-agent/build.gradle.kts
@@ -4,8 +4,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-validation")
 
-    // Spring AI - Claude (Anthropic)
-    implementation("org.springframework.ai:spring-ai-starter-model-anthropic")
+    // Spring AI - OpenAI
+    implementation("org.springframework.ai:spring-ai-starter-model-openai")
 
     // Spring AI - MCP Client
     implementation("org.springframework.ai:spring-ai-starter-mcp-client")

--- a/tally-agent/src/main/java/com/devpulse/agent/config/ChatMemoryConfig.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/config/ChatMemoryConfig.java
@@ -1,0 +1,17 @@
+package com.devpulse.agent.config;
+
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ChatMemoryConfig {
+
+    @Bean
+    ChatMemory chatMemory() {
+        return MessageWindowChatMemory.builder()
+                .maxMessages(20)
+                .build();
+    }
+}

--- a/tally-agent/src/main/java/com/devpulse/agent/controller/ChatController.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/controller/ChatController.java
@@ -1,12 +1,15 @@
 package com.devpulse.agent.controller;
 
+import com.devpulse.agent.dto.ChatRequest;
+import com.devpulse.agent.dto.ChatResponse;
 import com.devpulse.agent.service.AgentService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 
-import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/chat")
@@ -17,17 +20,40 @@ public class ChatController {
     private final AgentService agentService;
 
     @PostMapping
-    public Map<String, String> chat(@RequestBody Map<String, String> request) {
-        String message = request.get("message");
-        String githubToken = request.get("githubToken");
-        String response = agentService.chat(message, githubToken);
-        return Map.of("response", response);
+    public ChatResponse chat(@Valid @RequestBody ChatRequest request) {
+        String conversationId = resolveConversationId(request.getConversationId());
+
+        String response = agentService.chat(
+                request.getMessage(),
+                request.getGithubToken(),
+                conversationId
+        );
+
+        return ChatResponse.builder()
+                .response(response)
+                .conversationId(conversationId)
+                .build();
     }
 
     @PostMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<String> chatStream(@RequestBody Map<String, String> request) {
-        String message = request.get("message");
-        String githubToken = request.get("githubToken");
-        return agentService.chatStream(message, githubToken);
+    public Flux<String> chatStream(@RequestBody ChatRequest request) {
+        String conversationId = resolveConversationId(request.getConversationId());
+
+        return agentService.chatStream(
+                request.getMessage(),
+                request.getGithubToken(),
+                conversationId
+        );
+    }
+
+    @DeleteMapping("/conversations/{conversationId}")
+    public void clearConversation(@PathVariable String conversationId) {
+        agentService.clearConversation(conversationId);
+    }
+
+    private String resolveConversationId(String conversationId) {
+        return (conversationId != null && !conversationId.isBlank())
+                ? conversationId
+                : UUID.randomUUID().toString();
     }
 }

--- a/tally-agent/src/main/java/com/devpulse/agent/dto/ChatRequest.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/dto/ChatRequest.java
@@ -1,0 +1,15 @@
+package com.devpulse.agent.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ChatRequest {
+
+    @NotBlank(message = "Message is required")
+    private String message;
+
+    private String githubToken;
+
+    private String conversationId;
+}

--- a/tally-agent/src/main/java/com/devpulse/agent/dto/ChatResponse.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/dto/ChatResponse.java
@@ -1,0 +1,17 @@
+package com.devpulse.agent.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatResponse {
+
+    private String response;
+
+    private String conversationId;
+}

--- a/tally-agent/src/main/java/com/devpulse/agent/service/AgentService.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/service/AgentService.java
@@ -2,44 +2,103 @@ package com.devpulse.agent.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
+
+import java.util.UUID;
 
 @Slf4j
 @Service
 public class AgentService {
 
+    private static final String BASE_SYSTEM_PROMPT = """
+            You are DevPulse, an AI engineering intelligence coach that helps
+            development teams analyze GitHub repositories, diagnose team health,
+            and provide actionable insights.
+
+            ## Capabilities
+            You have access to GitHub analysis tools via MCP:
+            - listRepos: List user's accessible repositories
+            - analyzeRepo: Analyze contributions for a specific repository
+            - getCommitQuality: Analyze commit quality (Conventional Commits adherence)
+            - getPrQuality: Analyze PR quality (merge rate, review time)
+            - getOrgStats: Analyze organization-wide contributions
+            - compareRepos: Compare multiple repositories side by side
+            - listOrganizations: List user's organizations
+
+            ## Guidelines
+            - Provide data-driven insights backed by specific evidence from the tools.
+            - When analyzing, start with an overview then drill into specifics.
+            - Suggest actionable improvements based on metrics.
+            - Compare against industry best practices when relevant.
+            - If a tool call fails, explain the error and suggest alternatives.
+            - Respond in Korean when the user writes in Korean.
+            """;
+
     private final ChatClient chatClient;
+    private final ChatMemory chatMemory;
 
-    public AgentService(ChatClient.Builder chatClientBuilder) {
+    public AgentService(ChatClient.Builder chatClientBuilder, ChatMemory chatMemory) {
+        this.chatMemory = chatMemory;
         this.chatClient = chatClientBuilder
-                .defaultSystem("""
-                    You are DevPulse, an AI engineering intelligence coach.
-                    You help development teams by analyzing GitHub repositories,
-                    diagnosing team health, and providing actionable insights.
-
-                    You have access to MCP tools for GitHub analysis.
-                    Always provide data-driven insights with specific evidence.
-                    Respond in Korean when the user writes in Korean.
-                    """)
+                .defaultSystem(BASE_SYSTEM_PROMPT)
+                .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory).build())
                 .build();
     }
 
-    public String chat(String message, String githubToken) {
-        log.info("Chat request: {}", message);
+    public String chat(String message, String githubToken, String conversationId) {
+        conversationId = resolveConversationId(conversationId);
+        log.info("Chat request [conversationId={}]: {}", conversationId, message);
+
+        String systemPrompt = buildSystemPrompt(githubToken);
+        String cid = conversationId;
 
         return chatClient.prompt()
+                .system(systemPrompt)
                 .user(message)
+                .advisors(a -> a.param(ChatMemory.CONVERSATION_ID, cid))
                 .call()
                 .content();
     }
 
-    public Flux<String> chatStream(String message, String githubToken) {
-        log.info("Stream chat request: {}", message);
+    public Flux<String> chatStream(String message, String githubToken, String conversationId) {
+        conversationId = resolveConversationId(conversationId);
+        log.info("Stream chat request [conversationId={}]: {}", conversationId, message);
+
+        String systemPrompt = buildSystemPrompt(githubToken);
+        String cid = conversationId;
 
         return chatClient.prompt()
+                .system(systemPrompt)
                 .user(message)
+                .advisors(a -> a.param(ChatMemory.CONVERSATION_ID, cid))
                 .stream()
                 .content();
+    }
+
+    public void clearConversation(String conversationId) {
+        chatMemory.clear(conversationId);
+        log.info("Cleared conversation: {}", conversationId);
+    }
+
+    String resolveConversationId(String conversationId) {
+        return (conversationId != null && !conversationId.isBlank())
+                ? conversationId
+                : UUID.randomUUID().toString();
+    }
+
+    private String buildSystemPrompt(String githubToken) {
+        if (githubToken == null || githubToken.isBlank()) {
+            return BASE_SYSTEM_PROMPT;
+        }
+        return BASE_SYSTEM_PROMPT + """
+
+                ## GitHub Authentication
+                The user has provided a GitHub access token.
+                Use this token as the 'token' parameter for ALL GitHub tool calls: %s
+                Never reveal this token in your responses.
+                """.formatted(githubToken);
     }
 }

--- a/tally-agent/src/main/resources/application.yml
+++ b/tally-agent/src/main/resources/application.yml
@@ -2,11 +2,11 @@ spring:
   application:
     name: tally-agent
   ai:
-    anthropic:
-      api-key: ${ANTHROPIC_API_KEY:}
+    openai:
+      api-key: ${OPENAI_API_KEY:}
       chat:
         options:
-          model: claude-sonnet-4-20250514
+          model: gpt-4o
           max-tokens: 4096
     mcp:
       client:


### PR DESCRIPTION
## Summary
- Anthropic → **OpenAI (GPT-4o)** 모델 전환
- `MessageWindowChatMemory` 기반 세션별 대화 기억 (최근 20개 메시지 유지)
- `ChatRequest`/`ChatResponse` DTO 도입 + `conversationId` 세션 관리
- GitHub 토큰 시스템 프롬프트 주입으로 MCP 도구 호출 시 자동 전달
- `DELETE /api/chat/conversations/{id}` 대화 초기화 엔드포인트 추가

## Changes
| 파일 | 변경 |
|------|------|
| `build.gradle.kts` | `spring-ai-starter-model-anthropic` → `spring-ai-starter-model-openai` |
| `application.yml` | `spring.ai.openai` + `gpt-4o` 설정 |
| `docker-compose.yml` | `OPENAI_API_KEY` 환경변수 |
| `ChatMemoryConfig.java` (신규) | `MessageWindowChatMemory` 빈 |
| `ChatRequest.java` (신규) | 요청 DTO (message, githubToken, conversationId) |
| `ChatResponse.java` (신규) | 응답 DTO (response, conversationId) |
| `AgentService.java` | ChatMemory 통합 + 토큰 주입 + 세션 관리 |
| `ChatController.java` | DTO 적용 + 세션 관리 + 대화 삭제 API |

## Test plan
- [ ] `./gradlew clean build -x test` 빌드 확인 ✅
- [ ] `OPENAI_API_KEY` 설정 후 tally-agent + tally-mcp-github 기동 테스트
- [ ] `POST /api/chat` 요청 → 응답에 conversationId 포함 확인
- [ ] 같은 conversationId로 연속 요청 → 이전 대화 기억하는지 확인
- [ ] `DELETE /api/chat/conversations/{id}` → 대화 초기화 확인
- [ ] githubToken 포함 요청 → MCP 도구 호출 시 토큰 사용 확인

Closes #30