### PR TITLE
feat: K8s 클러스터 관리 + 서비스 모니터링 MCP Server (#35)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,12 @@ services:
     environment:
       - OPEN_AI_KEY=${OPEN_AI_KEY}
       - SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_GITHUB-MCP_URL=http://tally-mcp-github:8081
+      - SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_K8S-MCP_URL=http://tally-mcp-k8s:8082
+      - SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_MONITOR-MCP_URL=http://tally-mcp-monitor:8083
     depends_on:
       - tally-mcp-github
+      - tally-mcp-k8s
+      - tally-mcp-monitor
 
   tally-mcp-github:
     build:
@@ -28,8 +32,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8082:8082"
-    profiles:
-      - full
+    volumes:
+      - ${HOME}/.kube/config:/root/.kube/config:ro
 
   tally-mcp-monitor:
     build:
@@ -37,5 +41,10 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8083:8083"
-    profiles:
-      - full
+    environment:
+      - MONITOR_SERVICES_0_NAME=tally-agent
+      - MONITOR_SERVICES_0_URL=http://tally-agent:8080
+      - MONITOR_SERVICES_1_NAME=tally-mcp-github
+      - MONITOR_SERVICES_1_URL=http://tally-mcp-github:8081
+      - MONITOR_SERVICES_2_NAME=tally-mcp-k8s
+      - MONITOR_SERVICES_2_URL=http://tally-mcp-k8s:8082

--- a/k8s/configmap.yml
+++ b/k8s/configmap.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: devpulse-config
+  namespace: devpulse
+data:
+  # tally-agent
+  SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_GITHUB-MCP_URL: "http://tally-mcp-github:8081"
+  SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_K8S-MCP_URL: "http://tally-mcp-k8s:8082"
+  SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_MONITOR-MCP_URL: "http://tally-mcp-monitor:8083"
+  # tally-mcp-monitor (서비스 URL은 K8s 내부 DNS)
+  MONITOR_SERVICES_0_NAME: "tally-agent"
+  MONITOR_SERVICES_0_URL: "http://tally-agent:8080"
+  MONITOR_SERVICES_1_NAME: "tally-mcp-github"
+  MONITOR_SERVICES_1_URL: "http://tally-mcp-github:8081"
+  MONITOR_SERVICES_2_NAME: "tally-mcp-k8s"
+  MONITOR_SERVICES_2_URL: "http://tally-mcp-k8s:8082"

--- a/k8s/deployments.yml
+++ b/k8s/deployments.yml
@@ -1,0 +1,174 @@
+---
+# tally-agent — MCP Client + OpenAI Orchestrator
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tally-agent
+  namespace: devpulse
+  labels:
+    app: tally-agent
+    app.kubernetes.io/part-of: devpulse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tally-agent
+  template:
+    metadata:
+      labels:
+        app: tally-agent
+    spec:
+      containers:
+        - name: tally-agent
+          image: devpulse/tally-agent:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: OPEN_AI_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: devpulse-secrets
+                  key: openai-api-key
+          envFrom:
+            - configMapRef:
+                name: devpulse-config
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+
+---
+# tally-mcp-github — GitHub 분석 MCP Server
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tally-mcp-github
+  namespace: devpulse
+  labels:
+    app: tally-mcp-github
+    app.kubernetes.io/part-of: devpulse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tally-mcp-github
+  template:
+    metadata:
+      labels:
+        app: tally-mcp-github
+    spec:
+      containers:
+        - name: tally-mcp-github
+          image: devpulse/tally-mcp-github:latest
+          ports:
+            - containerPort: 8081
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "300m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8081
+            initialDelaySeconds: 20
+            periodSeconds: 10
+
+---
+# tally-mcp-k8s — Kubernetes 관리 MCP Server
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tally-mcp-k8s
+  namespace: devpulse
+  labels:
+    app: tally-mcp-k8s
+    app.kubernetes.io/part-of: devpulse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tally-mcp-k8s
+  template:
+    metadata:
+      labels:
+        app: tally-mcp-k8s
+    spec:
+      serviceAccountName: devpulse-k8s-sa
+      containers:
+        - name: tally-mcp-k8s
+          image: devpulse/tally-mcp-k8s:latest
+          ports:
+            - containerPort: 8082
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "300m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8082
+            initialDelaySeconds: 20
+            periodSeconds: 10
+
+---
+# tally-mcp-monitor — 서비스 모니터링 MCP Server
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tally-mcp-monitor
+  namespace: devpulse
+  labels:
+    app: tally-mcp-monitor
+    app.kubernetes.io/part-of: devpulse
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tally-mcp-monitor
+  template:
+    metadata:
+      labels:
+        app: tally-mcp-monitor
+    spec:
+      containers:
+        - name: tally-mcp-monitor
+          image: devpulse/tally-mcp-monitor:latest
+          ports:
+            - containerPort: 8083
+          envFrom:
+            - configMapRef:
+                name: devpulse-config
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "300m"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8083
+            initialDelaySeconds: 20
+            periodSeconds: 10

--- a/k8s/namespace.yml
+++ b/k8s/namespace.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: devpulse
+  labels:
+    app.kubernetes.io/part-of: devpulse

--- a/k8s/rbac.yml
+++ b/k8s/rbac.yml
@@ -1,0 +1,53 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: devpulse-k8s-sa
+  namespace: devpulse
+  labels:
+    app.kubernetes.io/part-of: devpulse
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devpulse-k8s-role
+rules:
+  # Pod 조회 + 로그
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  # Service 조회
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch"]
+  # Node 조회
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+  # Namespace 조회
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  # Deployment 조회 + 스케일링 + 업데이트(재시작)
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  # ReplicaSet 조회
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: devpulse-k8s-binding
+subjects:
+  - kind: ServiceAccount
+    name: devpulse-k8s-sa
+    namespace: devpulse
+roleRef:
+  kind: ClusterRole
+  name: devpulse-k8s-role
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/secrets.yml
+++ b/k8s/secrets.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: devpulse-secrets
+  namespace: devpulse
+type: Opaque
+stringData:
+  openai-api-key: "YOUR_OPENAI_API_KEY_HERE"

--- a/k8s/services.yml
+++ b/k8s/services.yml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tally-agent
+  namespace: devpulse
+  labels:
+    app: tally-agent
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: tally-agent
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tally-mcp-github
+  namespace: devpulse
+  labels:
+    app: tally-mcp-github
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8081
+      targetPort: 8081
+      protocol: TCP
+  selector:
+    app: tally-mcp-github
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tally-mcp-k8s
+  namespace: devpulse
+  labels:
+    app: tally-mcp-k8s
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8082
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: tally-mcp-k8s
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tally-mcp-monitor
+  namespace: devpulse
+  labels:
+    app: tally-mcp-monitor
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8083
+      targetPort: 8083
+      protocol: TCP
+  selector:
+    app: tally-mcp-monitor

--- a/tally-agent/Dockerfile
+++ b/tally-agent/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/tally-agent/src/main/java/com/devpulse/agent/service/AgentService.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/service/AgentService.java
@@ -60,6 +60,32 @@ public class AgentService {
             4. Use calculateDoraMetrics for overall engineering maturity assessment
             5. Generate getRecentActivity or generateSprintReport for period summaries
 
+            ### Kubernetes Cluster Management
+            - listPods: List Pods in a namespace (status, ready, restarts, node)
+            - getPodDetails: Get detailed Pod info (containers, resources, conditions)
+            - getPodLogs: Tail Pod logs for debugging
+            - listDeployments: List Deployments (replica status, images)
+            - scaleDeployment: Scale Deployment replicas up/down
+            - restartDeployment: Rolling restart a Deployment (zero-downtime)
+            - listServices: List Services (type, cluster IP, ports)
+            - getClusterStatus: Get cluster overview (nodes, namespaces, resources)
+
+            ### Service Monitoring
+            - checkHealth: Check service health via Actuator /health
+            - getMetrics: Query Actuator metrics (list or specific metric)
+            - getServiceInfo: Get service info via Actuator /info
+            - checkAllServices: Health check all registered services at once
+            - getJvmMetrics: Get JVM metrics (heap, GC, threads, CPU, uptime)
+            - getHttpMetrics: Get HTTP request metrics (count, response time, status codes)
+
+            ## Kubernetes Operations Workflow
+            When managing infrastructure:
+            1. Use getClusterStatus for cluster overview
+            2. Use listDeployments/listPods to check workload status
+            3. Use getPodLogs when debugging issues
+            4. Use scaleDeployment/restartDeployment for remediation
+            5. Use checkAllServices to verify service health after changes
+
             ## Guidelines
             - Provide data-driven insights backed by specific evidence from the tools.
             - When analyzing, start with an overview then drill into specifics.

--- a/tally-agent/src/main/resources/application.yml
+++ b/tally-agent/src/main/resources/application.yml
@@ -22,6 +22,10 @@ spring:
           connections:
             github-mcp:
               url: http://localhost:8081
+            k8s-mcp:
+              url: http://localhost:8082
+            monitor-mcp:
+              url: http://localhost:8083
 
 server:
   port: 8080

--- a/tally-mcp-github/Dockerfile
+++ b/tally-mcp-github/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY build/libs/*.jar app.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/tally-mcp-k8s/Dockerfile
+++ b/tally-mcp-k8s/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY build/libs/*.jar app.jar
+EXPOSE 8082
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/tally-mcp-k8s/build.gradle.kts
+++ b/tally-mcp-k8s/build.gradle.kts
@@ -5,6 +5,9 @@ dependencies {
     // Spring AI - MCP Server (WebMVC transport with SSE)
     implementation("org.springframework.ai:spring-ai-starter-mcp-server-webmvc")
 
+    // Actuator
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
     // Kubernetes Java Client
     implementation("io.kubernetes:client-java:21.0.1")
 }

--- a/tally-mcp-k8s/src/main/java/com/devpulse/mcp/k8s/service/KubernetesService.java
+++ b/tally-mcp-k8s/src/main/java/com/devpulse/mcp/k8s/service/KubernetesService.java
@@ -1,0 +1,440 @@
+package com.devpulse.mcp.k8s.service;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.*;
+import io.kubernetes.client.util.Config;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class KubernetesService {
+
+    private CoreV1Api coreApi;
+    private AppsV1Api appsApi;
+    private boolean connected = false;
+
+    @PostConstruct
+    public void init() {
+        try {
+            ApiClient client = Config.defaultClient();
+            client.setReadTimeout(10000);
+            Configuration.setDefaultApiClient(client);
+            coreApi = new CoreV1Api(client);
+            appsApi = new AppsV1Api(client);
+            connected = true;
+            log.info("Kubernetes client initialized successfully");
+        } catch (Exception e) {
+            log.warn("Kubernetes client initialization failed: {}. Tools will return error messages.", e.getMessage());
+            connected = false;
+        }
+    }
+
+    private void ensureConnected() {
+        if (!connected) {
+            throw new IllegalStateException("Kubernetes 클러스터에 연결되지 않았습니다. kubeconfig를 확인해주세요.");
+        }
+    }
+
+    public String listPods(String namespace) {
+        ensureConnected();
+        try {
+            V1PodList podList = coreApi.listNamespacedPod(namespace)
+                    .execute();
+
+            if (podList.getItems().isEmpty()) {
+                return "## Pod 목록 — " + namespace + "\n\n> Pod가 없습니다.";
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("## Pod 목록 — ").append(namespace).append("\n\n");
+            sb.append("| Pod 이름 | 상태 | Ready | 재시작 | 노드 | 실행 시간 |\n");
+            sb.append("|----------|------|-------|--------|------|----------|\n");
+
+            for (V1Pod pod : podList.getItems()) {
+                String name = pod.getMetadata().getName();
+                String phase = pod.getStatus().getPhase();
+
+                // Ready containers count
+                int readyCount = 0;
+                int totalCount = 0;
+                int restarts = 0;
+                if (pod.getStatus().getContainerStatuses() != null) {
+                    totalCount = pod.getStatus().getContainerStatuses().size();
+                    for (V1ContainerStatus cs : pod.getStatus().getContainerStatuses()) {
+                        if (Boolean.TRUE.equals(cs.getReady())) readyCount++;
+                        restarts += cs.getRestartCount();
+                    }
+                }
+
+                String node = pod.getSpec().getNodeName() != null ? pod.getSpec().getNodeName() : "-";
+                String age = formatAge(pod.getMetadata().getCreationTimestamp());
+
+                String statusEmoji = "Running".equals(phase) ? "✅" : "Pending".equals(phase) ? "⏳" : "❌";
+                sb.append(String.format("| %s | %s %s | %d/%d | %d | %s | %s |\n",
+                        name, statusEmoji, phase, readyCount, totalCount, restarts, node, age));
+            }
+
+            sb.append("\n**총 ").append(podList.getItems().size()).append("개 Pod**");
+            return sb.toString();
+
+        } catch (ApiException e) {
+            return handleApiException("Pod 목록 조회", e);
+        }
+    }
+
+    public String getPodDetails(String namespace, String podName) {
+        ensureConnected();
+        try {
+            V1Pod pod = coreApi.readNamespacedPod(podName, namespace)
+                    .execute();
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("## Pod 상세 — ").append(podName).append("\n\n");
+
+            // Basic info
+            sb.append("### 기본 정보\n");
+            sb.append("- **네임스페이스**: ").append(namespace).append("\n");
+            sb.append("- **상태**: ").append(pod.getStatus().getPhase()).append("\n");
+            sb.append("- **노드**: ").append(pod.getSpec().getNodeName()).append("\n");
+            sb.append("- **IP**: ").append(pod.getStatus().getPodIP()).append("\n");
+            sb.append("- **생성일**: ").append(pod.getMetadata().getCreationTimestamp()).append("\n");
+
+            // Labels
+            if (pod.getMetadata().getLabels() != null && !pod.getMetadata().getLabels().isEmpty()) {
+                sb.append("\n### 레이블\n");
+                pod.getMetadata().getLabels().forEach((k, v) ->
+                        sb.append("- `").append(k).append("`: ").append(v).append("\n"));
+            }
+
+            // Containers
+            sb.append("\n### 컨테이너\n");
+            sb.append("| 이름 | 이미지 | Ready | 재시작 | 상태 |\n");
+            sb.append("|------|--------|-------|--------|------|\n");
+
+            if (pod.getStatus().getContainerStatuses() != null) {
+                for (V1ContainerStatus cs : pod.getStatus().getContainerStatuses()) {
+                    String state = "Unknown";
+                    if (cs.getState() != null) {
+                        if (cs.getState().getRunning() != null) state = "Running";
+                        else if (cs.getState().getWaiting() != null) state = "Waiting: " + cs.getState().getWaiting().getReason();
+                        else if (cs.getState().getTerminated() != null) state = "Terminated: " + cs.getState().getTerminated().getReason();
+                    }
+                    sb.append(String.format("| %s | %s | %s | %d | %s |\n",
+                            cs.getName(), cs.getImage(),
+                            Boolean.TRUE.equals(cs.getReady()) ? "✅" : "❌",
+                            cs.getRestartCount(), state));
+                }
+            }
+
+            // Resource requests/limits
+            sb.append("\n### 리소스\n");
+            if (pod.getSpec().getContainers() != null) {
+                for (V1Container container : pod.getSpec().getContainers()) {
+                    sb.append("**").append(container.getName()).append("**:\n");
+                    if (container.getResources() != null) {
+                        if (container.getResources().getRequests() != null) {
+                            sb.append("- Requests: ");
+                            container.getResources().getRequests().forEach((k, v) ->
+                                    sb.append(k).append("=").append(v.toSuffixedString()).append(" "));
+                            sb.append("\n");
+                        }
+                        if (container.getResources().getLimits() != null) {
+                            sb.append("- Limits: ");
+                            container.getResources().getLimits().forEach((k, v) ->
+                                    sb.append(k).append("=").append(v.toSuffixedString()).append(" "));
+                            sb.append("\n");
+                        }
+                    } else {
+                        sb.append("- 리소스 제한 없음\n");
+                    }
+                }
+            }
+
+            // Conditions
+            if (pod.getStatus().getConditions() != null) {
+                sb.append("\n### 조건\n");
+                sb.append("| 유형 | 상태 | 메시지 |\n");
+                sb.append("|------|------|--------|\n");
+                for (V1PodCondition cond : pod.getStatus().getConditions()) {
+                    sb.append(String.format("| %s | %s | %s |\n",
+                            cond.getType(),
+                            "True".equals(cond.getStatus()) ? "✅" : "❌",
+                            cond.getMessage() != null ? cond.getMessage() : "-"));
+                }
+            }
+
+            return sb.toString();
+
+        } catch (ApiException e) {
+            return handleApiException("Pod 상세 조회", e);
+        }
+    }
+
+    public String getPodLogs(String namespace, String podName, int tailLines) {
+        ensureConnected();
+        try {
+            String logs = coreApi.readNamespacedPodLog(podName, namespace)
+                    .tailLines(tailLines)
+                    .execute();
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("## Pod 로그 — ").append(podName).append("\n\n");
+            sb.append("최근 ").append(tailLines).append("줄:\n\n");
+            sb.append("```\n");
+            sb.append(logs != null ? logs : "(로그 없음)");
+            sb.append("\n```\n");
+            return sb.toString();
+
+        } catch (ApiException e) {
+            return handleApiException("Pod 로그 조회", e);
+        }
+    }
+
+    public String listDeployments(String namespace) {
+        ensureConnected();
+        try {
+            V1DeploymentList deployList = appsApi.listNamespacedDeployment(namespace)
+                    .execute();
+
+            if (deployList.getItems().isEmpty()) {
+                return "## Deployment 목록 — " + namespace + "\n\n> Deployment가 없습니다.";
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("## Deployment 목록 — ").append(namespace).append("\n\n");
+            sb.append("| 이름 | Ready | Up-to-date | Available | 이미지 | 생성일 |\n");
+            sb.append("|------|-------|-----------|-----------|--------|--------|\n");
+
+            for (V1Deployment deploy : deployList.getItems()) {
+                String name = deploy.getMetadata().getName();
+                V1DeploymentStatus status = deploy.getStatus();
+
+                int ready = status.getReadyReplicas() != null ? status.getReadyReplicas() : 0;
+                int desired = deploy.getSpec().getReplicas() != null ? deploy.getSpec().getReplicas() : 0;
+                int upToDate = status.getUpdatedReplicas() != null ? status.getUpdatedReplicas() : 0;
+                int available = status.getAvailableReplicas() != null ? status.getAvailableReplicas() : 0;
+
+                String image = deploy.getSpec().getTemplate().getSpec().getContainers().stream()
+                        .map(V1Container::getImage)
+                        .collect(Collectors.joining(", "));
+
+                String age = formatAge(deploy.getMetadata().getCreationTimestamp());
+
+                String statusIcon = (ready == desired && desired > 0) ? "✅" : "⚠️";
+                sb.append(String.format("| %s %s | %d/%d | %d | %d | %s | %s |\n",
+                        statusIcon, name, ready, desired, upToDate, available, image, age));
+            }
+
+            sb.append("\n**총 ").append(deployList.getItems().size()).append("개 Deployment**");
+            return sb.toString();
+
+        } catch (ApiException e) {
+            return handleApiException("Deployment 목록 조회", e);
+        }
+    }
+
+    public String scaleDeployment(String namespace, String deploymentName, int replicas) {
+        ensureConnected();
+        try {
+            V1Deployment deployment = appsApi.readNamespacedDeployment(deploymentName, namespace)
+                    .execute();
+
+            int currentReplicas = deployment.getSpec().getReplicas() != null ? deployment.getSpec().getReplicas() : 0;
+            deployment.getSpec().setReplicas(replicas);
+
+            appsApi.replaceNamespacedDeployment(deploymentName, namespace, deployment)
+                    .execute();
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("## Deployment 스케일링 완료\n\n");
+            sb.append("- **Deployment**: ").append(deploymentName).append("\n");
+            sb.append("- **네임스페이스**: ").append(namespace).append("\n");
+            sb.append("- **변경**: ").append(currentReplicas).append(" → ").append(replicas).append(" replicas\n");
+
+            if (replicas > currentReplicas) {
+                sb.append("\n> ℹ️ 스케일 업: 새로운 Pod가 생성됩니다. `listPods`로 상태를 확인하세요.");
+            } else if (replicas < currentReplicas) {
+                sb.append("\n> ⚠️ 스케일 다운: 일부 Pod가 종료됩니다.");
+            }
+
+            return sb.toString();
+
+        } catch (ApiException e) {
+            return handleApiException("Deployment 스케일링", e);
+        }
+    }
+
+    public String restartDeployment(String namespace, String deploymentName) {
+        ensureConnected();
+        try {
+            V1Deployment deployment = appsApi.readNamespacedDeployment(deploymentName, namespace)
+                    .execute();
+
+            // Trigger rolling restart by updating annotation
+            Map<String, String> annotations = deployment.getSpec().getTemplate().getMetadata().getAnnotations();
+            if (annotations == null) {
+                annotations = new HashMap<>();
+                deployment.getSpec().getTemplate().getMetadata().setAnnotations(annotations);
+            }
+            annotations.put("kubectl.kubernetes.io/restartedAt", OffsetDateTime.now().toString());
+
+            appsApi.replaceNamespacedDeployment(deploymentName, namespace, deployment)
+                    .execute();
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("## Deployment 재시작 요청 완료\n\n");
+            sb.append("- **Deployment**: ").append(deploymentName).append("\n");
+            sb.append("- **네임스페이스**: ").append(namespace).append("\n");
+            sb.append("- **방식**: 롤링 재시작 (zero-downtime)\n");
+            sb.append("\n> ℹ️ 기존 Pod가 순차적으로 교체됩니다. `listPods`로 진행 상태를 확인하세요.");
+            return sb.toString();
+
+        } catch (ApiException e) {
+            return handleApiException("Deployment 재시작", e);
+        }
+    }
+
+    public String listServices(String namespace) {
+        ensureConnected();
+        try {
+            V1ServiceList serviceList = coreApi.listNamespacedService(namespace)
+                    .execute();
+
+            if (serviceList.getItems().isEmpty()) {
+                return "## Service 목록 — " + namespace + "\n\n> Service가 없습니다.";
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("## Service 목록 — ").append(namespace).append("\n\n");
+            sb.append("| 이름 | 타입 | Cluster IP | 포트 | 생성일 |\n");
+            sb.append("|------|------|-----------|------|--------|\n");
+
+            for (V1Service svc : serviceList.getItems()) {
+                String name = svc.getMetadata().getName();
+                String type = svc.getSpec().getType();
+                String clusterIP = svc.getSpec().getClusterIP();
+
+                String ports = "";
+                if (svc.getSpec().getPorts() != null) {
+                    ports = svc.getSpec().getPorts().stream()
+                            .map(p -> {
+                                String portStr = p.getPort().toString();
+                                if (p.getNodePort() != null) portStr += ":" + p.getNodePort();
+                                portStr += "/" + p.getProtocol();
+                                return portStr;
+                            })
+                            .collect(Collectors.joining(", "));
+                }
+
+                String age = formatAge(svc.getMetadata().getCreationTimestamp());
+                sb.append(String.format("| %s | %s | %s | %s | %s |\n",
+                        name, type, clusterIP, ports, age));
+            }
+
+            sb.append("\n**총 ").append(serviceList.getItems().size()).append("개 Service**");
+            return sb.toString();
+
+        } catch (ApiException e) {
+            return handleApiException("Service 목록 조회", e);
+        }
+    }
+
+    public String getClusterStatus() {
+        ensureConnected();
+        try {
+            V1NodeList nodeList = coreApi.listNode().execute();
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("## 클러스터 상태\n\n");
+
+            // Node info
+            sb.append("### 노드\n");
+            sb.append("| 노드 이름 | 상태 | 역할 | 버전 | OS | 아키텍처 |\n");
+            sb.append("|-----------|------|------|------|-----|----------|\n");
+
+            for (V1Node node : nodeList.getItems()) {
+                String nodeName = node.getMetadata().getName();
+
+                String status = "Unknown";
+                if (node.getStatus().getConditions() != null) {
+                    for (V1NodeCondition cond : node.getStatus().getConditions()) {
+                        if ("Ready".equals(cond.getType())) {
+                            status = "True".equals(cond.getStatus()) ? "✅ Ready" : "❌ NotReady";
+                        }
+                    }
+                }
+
+                String roles = "";
+                if (node.getMetadata().getLabels() != null) {
+                    roles = node.getMetadata().getLabels().entrySet().stream()
+                            .filter(e -> e.getKey().contains("node-role.kubernetes.io/"))
+                            .map(e -> e.getKey().replace("node-role.kubernetes.io/", ""))
+                            .collect(Collectors.joining(", "));
+                    if (roles.isEmpty()) roles = "worker";
+                }
+
+                V1NodeSystemInfo info = node.getStatus().getNodeInfo();
+                sb.append(String.format("| %s | %s | %s | %s | %s | %s |\n",
+                        nodeName, status, roles,
+                        info.getKubeletVersion(),
+                        info.getOsImage(),
+                        info.getArchitecture()));
+            }
+
+            // Namespace summary
+            V1NamespaceList nsList = coreApi.listNamespace().execute();
+            sb.append("\n### 네임스페이스 요약\n");
+            sb.append("| 네임스페이스 | 상태 | Pod 수 |\n");
+            sb.append("|-------------|------|--------|\n");
+
+            for (V1Namespace ns : nsList.getItems()) {
+                String nsName = ns.getMetadata().getName();
+                try {
+                    V1PodList pods = coreApi.listNamespacedPod(nsName).execute();
+                    sb.append(String.format("| %s | %s | %d |\n",
+                            nsName, ns.getStatus().getPhase(), pods.getItems().size()));
+                } catch (ApiException ignored) {
+                    sb.append(String.format("| %s | %s | - |\n",
+                            nsName, ns.getStatus().getPhase()));
+                }
+            }
+
+            sb.append("\n**총 ").append(nodeList.getItems().size()).append("개 노드, ")
+                    .append(nsList.getItems().size()).append("개 네임스페이스**");
+
+            return sb.toString();
+
+        } catch (ApiException e) {
+            return handleApiException("클러스터 상태 조회", e);
+        }
+    }
+
+    private String formatAge(OffsetDateTime createdAt) {
+        if (createdAt == null) return "-";
+        Duration duration = Duration.between(createdAt.toInstant(), OffsetDateTime.now().toInstant());
+        long days = duration.toDays();
+        if (days > 0) return days + "d";
+        long hours = duration.toHours();
+        if (hours > 0) return hours + "h";
+        long minutes = duration.toMinutes();
+        return minutes + "m";
+    }
+
+    private String handleApiException(String operation, ApiException e) {
+        log.error("{} 실패: {} - {}", operation, e.getCode(), e.getResponseBody());
+        return String.format("## ❌ %s 실패\n\n- **HTTP %d**: %s\n- **상세**: %s",
+                operation, e.getCode(), e.getMessage(),
+                e.getResponseBody() != null ? e.getResponseBody() : "없음");
+    }
+}

--- a/tally-mcp-k8s/src/main/java/com/devpulse/mcp/k8s/tools/KubernetesTools.java
+++ b/tally-mcp-k8s/src/main/java/com/devpulse/mcp/k8s/tools/KubernetesTools.java
@@ -1,0 +1,81 @@
+package com.devpulse.mcp.k8s.tools;
+
+import com.devpulse.mcp.k8s.service.KubernetesService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+/**
+ * MCP Server 도구 — Kubernetes 클러스터 관리
+ * Pod/Deployment/Service 조회, 스케일링, 재시작, 로그 조회
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KubernetesTools {
+
+    private final KubernetesService kubernetesService;
+
+    @Tool(description = "Kubernetes 네임스페이스의 Pod 목록을 조회합니다. 각 Pod의 상태, Ready 여부, 재시작 횟수, 노드, 실행 시간을 반환합니다.")
+    public String listPods(
+            @ToolParam(description = "Kubernetes 네임스페이스 (예: default, devpulse)") String namespace) {
+        log.info("Tool: list_pods namespace={}", namespace);
+        return kubernetesService.listPods(namespace);
+    }
+
+    @Tool(description = "특정 Pod의 상세 정보를 조회합니다. 기본 정보, 레이블, 컨테이너 상태, 리소스 요청/제한, 조건을 반환합니다.")
+    public String getPodDetails(
+            @ToolParam(description = "Kubernetes 네임스페이스") String namespace,
+            @ToolParam(description = "Pod 이름") String podName) {
+        log.info("Tool: get_pod_details namespace={} pod={}", namespace, podName);
+        return kubernetesService.getPodDetails(namespace, podName);
+    }
+
+    @Tool(description = "Pod의 최근 로그를 조회합니다. 에러 디버깅, 애플리케이션 상태 확인에 활용합니다.")
+    public String getPodLogs(
+            @ToolParam(description = "Kubernetes 네임스페이스") String namespace,
+            @ToolParam(description = "Pod 이름") String podName,
+            @ToolParam(description = "조회할 로그 줄 수 (기본 100)") int tailLines) {
+        log.info("Tool: get_pod_logs namespace={} pod={} lines={}", namespace, podName, tailLines);
+        return kubernetesService.getPodLogs(namespace, podName, Math.min(tailLines, 500));
+    }
+
+    @Tool(description = "Kubernetes 네임스페이스의 Deployment 목록을 조회합니다. 각 Deployment의 레플리카 상태, 이미지, 생성일을 반환합니다.")
+    public String listDeployments(
+            @ToolParam(description = "Kubernetes 네임스페이스") String namespace) {
+        log.info("Tool: list_deployments namespace={}", namespace);
+        return kubernetesService.listDeployments(namespace);
+    }
+
+    @Tool(description = "Deployment의 레플리카 수를 변경합니다 (스케일 업/다운). 트래픽 증가 대응이나 리소스 절약에 활용합니다.")
+    public String scaleDeployment(
+            @ToolParam(description = "Kubernetes 네임스페이스") String namespace,
+            @ToolParam(description = "Deployment 이름") String deploymentName,
+            @ToolParam(description = "변경할 레플리카 수") int replicas) {
+        log.info("Tool: scale_deployment namespace={} deployment={} replicas={}", namespace, deploymentName, replicas);
+        return kubernetesService.scaleDeployment(namespace, deploymentName, replicas);
+    }
+
+    @Tool(description = "Deployment를 롤링 재시작합니다. 설정 변경 적용이나 문제 해결을 위해 Pod를 순차적으로 교체합니다. zero-downtime으로 진행됩니다.")
+    public String restartDeployment(
+            @ToolParam(description = "Kubernetes 네임스페이스") String namespace,
+            @ToolParam(description = "Deployment 이름") String deploymentName) {
+        log.info("Tool: restart_deployment namespace={} deployment={}", namespace, deploymentName);
+        return kubernetesService.restartDeployment(namespace, deploymentName);
+    }
+
+    @Tool(description = "Kubernetes 네임스페이스의 Service 목록을 조회합니다. 각 Service의 타입, Cluster IP, 포트 정보를 반환합니다.")
+    public String listServices(
+            @ToolParam(description = "Kubernetes 네임스페이스") String namespace) {
+        log.info("Tool: list_services namespace={}", namespace);
+        return kubernetesService.listServices(namespace);
+    }
+
+    @Tool(description = "Kubernetes 클러스터의 전체 상태를 조회합니다. 노드 정보, 네임스페이스별 Pod 수, 클러스터 리소스 현황을 반환합니다.")
+    public String getClusterStatus() {
+        log.info("Tool: get_cluster_status");
+        return kubernetesService.getClusterStatus();
+    }
+}

--- a/tally-mcp-k8s/src/main/resources/application.yml
+++ b/tally-mcp-k8s/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
       server:
         name: tally-mcp-k8s
         version: 3.0.0
+        type: SYNC
+        instructions: "Kubernetes 클러스터 모니터링 및 제어 도구를 제공하는 MCP Server입니다. Pod, Deployment, Service 조회/스케일링/재시작 기능을 지원합니다."
+        capabilities:
+          tool: true
+        sse-message-endpoint: /mcp/messages
 
 server:
   port: 8082
@@ -13,3 +18,4 @@ server:
 logging:
   level:
     com.devpulse: DEBUG
+    org.springframework.ai.mcp: DEBUG

--- a/tally-mcp-monitor/Dockerfile
+++ b/tally-mcp-monitor/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY build/libs/*.jar app.jar
+EXPOSE 8083
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/tally-mcp-monitor/src/main/java/com/devpulse/mcp/monitor/config/MonitorConfig.java
+++ b/tally-mcp-monitor/src/main/java/com/devpulse/mcp/monitor/config/MonitorConfig.java
@@ -1,0 +1,22 @@
+package com.devpulse.mcp.monitor.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "monitor")
+public class MonitorConfig {
+
+    private List<ServiceEntry> services = new ArrayList<>();
+
+    @Data
+    public static class ServiceEntry {
+        private String name;
+        private String url;
+    }
+}

--- a/tally-mcp-monitor/src/main/java/com/devpulse/mcp/monitor/service/ServiceMonitorService.java
+++ b/tally-mcp-monitor/src/main/java/com/devpulse/mcp/monitor/service/ServiceMonitorService.java
@@ -1,0 +1,377 @@
+package com.devpulse.mcp.monitor.service;
+
+import com.devpulse.mcp.monitor.config.MonitorConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ServiceMonitorService {
+
+    private final MonitorConfig monitorConfig;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final WebClient webClient = WebClient.builder()
+            .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(5 * 1024 * 1024))
+            .build();
+
+    public String checkHealth(String serviceUrl) {
+        try {
+            String response = fetchActuator(serviceUrl, "/actuator/health");
+            JsonNode health = objectMapper.readTree(response);
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("## 서비스 헬스체크 — ").append(serviceUrl).append("\n\n");
+
+            String status = health.path("status").asText("UNKNOWN");
+            String statusIcon = "UP".equals(status) ? "✅" : "DOWN".equals(status) ? "❌" : "⚠️";
+            sb.append("**상태**: ").append(statusIcon).append(" ").append(status).append("\n\n");
+
+            // Component details
+            JsonNode components = health.path("components");
+            if (!components.isMissingNode()) {
+                sb.append("### 컴포넌트\n");
+                sb.append("| 컴포넌트 | 상태 | 상세 |\n");
+                sb.append("|----------|------|------|\n");
+
+                components.fields().forEachRemaining(entry -> {
+                    String compName = entry.getKey();
+                    JsonNode comp = entry.getValue();
+                    String compStatus = comp.path("status").asText("UNKNOWN");
+                    String icon = "UP".equals(compStatus) ? "✅" : "❌";
+
+                    String details = "";
+                    JsonNode detailNode = comp.path("details");
+                    if (!detailNode.isMissingNode()) {
+                        details = detailNode.toString();
+                        if (details.length() > 100) details = details.substring(0, 100) + "...";
+                    }
+
+                    sb.append(String.format("| %s | %s %s | %s |\n", compName, icon, compStatus, details));
+                });
+            }
+
+            return sb.toString();
+
+        } catch (Exception e) {
+            return formatError("헬스체크", serviceUrl, e);
+        }
+    }
+
+    public String getMetrics(String serviceUrl, String metricName) {
+        try {
+            if (metricName == null || metricName.isBlank()) {
+                // List all available metrics
+                String response = fetchActuator(serviceUrl, "/actuator/metrics");
+                JsonNode metricsNode = objectMapper.readTree(response);
+
+                StringBuilder sb = new StringBuilder();
+                sb.append("## 사용 가능한 메트릭 — ").append(serviceUrl).append("\n\n");
+
+                JsonNode names = metricsNode.path("names");
+                if (names.isArray()) {
+                    // Group by prefix
+                    Map<String, List<String>> grouped = new TreeMap<>();
+                    for (JsonNode name : names) {
+                        String n = name.asText();
+                        String prefix = n.contains(".") ? n.substring(0, n.indexOf('.')) : n;
+                        grouped.computeIfAbsent(prefix, k -> new ArrayList<>()).add(n);
+                    }
+
+                    for (Map.Entry<String, List<String>> group : grouped.entrySet()) {
+                        sb.append("### ").append(group.getKey()).append("\n");
+                        for (String metric : group.getValue()) {
+                            sb.append("- `").append(metric).append("`\n");
+                        }
+                        sb.append("\n");
+                    }
+                }
+
+                return sb.toString();
+            }
+
+            // Get specific metric
+            String response = fetchActuator(serviceUrl, "/actuator/metrics/" + metricName);
+            JsonNode metric = objectMapper.readTree(response);
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("## 메트릭: ").append(metricName).append("\n\n");
+            sb.append("- **설명**: ").append(metric.path("description").asText("-")).append("\n");
+            sb.append("- **단위**: ").append(metric.path("baseUnit").asText("-")).append("\n\n");
+
+            JsonNode measurements = metric.path("measurements");
+            if (measurements.isArray()) {
+                sb.append("### 측정값\n");
+                sb.append("| 통계 | 값 |\n");
+                sb.append("|------|----|\n");
+                for (JsonNode m : measurements) {
+                    sb.append(String.format("| %s | %.4f |\n",
+                            m.path("statistic").asText(), m.path("value").asDouble()));
+                }
+            }
+
+            JsonNode tags = metric.path("availableTags");
+            if (tags.isArray() && !tags.isEmpty()) {
+                sb.append("\n### 필터 태그\n");
+                for (JsonNode tag : tags) {
+                    sb.append("- **").append(tag.path("tag").asText()).append("**: ");
+                    JsonNode values = tag.path("values");
+                    if (values.isArray()) {
+                        List<String> vals = new ArrayList<>();
+                        values.forEach(v -> vals.add(v.asText()));
+                        sb.append(String.join(", ", vals));
+                    }
+                    sb.append("\n");
+                }
+            }
+
+            return sb.toString();
+
+        } catch (Exception e) {
+            return formatError("메트릭 조회", serviceUrl, e);
+        }
+    }
+
+    public String getServiceInfo(String serviceUrl) {
+        try {
+            String response = fetchActuator(serviceUrl, "/actuator/info");
+            JsonNode info = objectMapper.readTree(response);
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("## 서비스 정보 — ").append(serviceUrl).append("\n\n");
+
+            if (info.isEmpty()) {
+                sb.append("> 등록된 정보가 없습니다. `management.info.*` 설정을 확인하세요.\n");
+            } else {
+                sb.append("```json\n");
+                sb.append(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(info));
+                sb.append("\n```\n");
+            }
+
+            return sb.toString();
+
+        } catch (Exception e) {
+            return formatError("서비스 정보 조회", serviceUrl, e);
+        }
+    }
+
+    public String checkAllServices() {
+        List<MonitorConfig.ServiceEntry> services = monitorConfig.getServices();
+        if (services.isEmpty()) {
+            return "## 전체 서비스 헬스체크\n\n> 등록된 모니터링 대상 서비스가 없습니다.";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("## 전체 서비스 헬스체크\n\n");
+        sb.append("| 서비스 | URL | 상태 | 응답 시간 |\n");
+        sb.append("|--------|-----|------|----------|\n");
+
+        int upCount = 0;
+        int totalCount = services.size();
+
+        for (MonitorConfig.ServiceEntry service : services) {
+            long start = System.currentTimeMillis();
+            String status;
+            String icon;
+
+            try {
+                String response = fetchActuator(service.getUrl(), "/actuator/health");
+                JsonNode health = objectMapper.readTree(response);
+                status = health.path("status").asText("UNKNOWN");
+                icon = "UP".equals(status) ? "✅" : "❌";
+                if ("UP".equals(status)) upCount++;
+            } catch (Exception e) {
+                status = "DOWN";
+                icon = "❌";
+            }
+
+            long elapsed = System.currentTimeMillis() - start;
+            sb.append(String.format("| %s | %s | %s %s | %dms |\n",
+                    service.getName(), service.getUrl(), icon, status, elapsed));
+        }
+
+        sb.append("\n**결과**: ").append(upCount).append("/").append(totalCount).append(" 서비스 정상");
+
+        if (upCount < totalCount) {
+            sb.append("\n\n> ⚠️ ").append(totalCount - upCount).append("개 서비스가 비정상 상태입니다.");
+        } else {
+            sb.append("\n\n> ✅ 모든 서비스가 정상 동작 중입니다.");
+        }
+
+        return sb.toString();
+    }
+
+    public String getJvmMetrics(String serviceUrl) {
+        try {
+            StringBuilder sb = new StringBuilder();
+            sb.append("## JVM 메트릭 — ").append(serviceUrl).append("\n\n");
+
+            // Heap memory
+            sb.append("### 힙 메모리\n");
+            appendMetricValue(sb, serviceUrl, "jvm.memory.used", "tags=area:heap", "사용량");
+            appendMetricValue(sb, serviceUrl, "jvm.memory.max", "tags=area:heap", "최대");
+            appendMetricValue(sb, serviceUrl, "jvm.memory.committed", "tags=area:heap", "할당");
+
+            // Non-heap memory
+            sb.append("\n### 논힙 메모리\n");
+            appendMetricValue(sb, serviceUrl, "jvm.memory.used", "tags=area:nonheap", "사용량");
+            appendMetricValue(sb, serviceUrl, "jvm.memory.committed", "tags=area:nonheap", "할당");
+
+            // GC
+            sb.append("\n### 가비지 컬렉션\n");
+            appendMetricValue(sb, serviceUrl, "jvm.gc.pause", null, "GC 일시정지");
+
+            // Threads
+            sb.append("\n### 스레드\n");
+            appendMetricValue(sb, serviceUrl, "jvm.threads.live", null, "활성 스레드");
+            appendMetricValue(sb, serviceUrl, "jvm.threads.peak", null, "최대 스레드");
+            appendMetricValue(sb, serviceUrl, "jvm.threads.daemon", null, "데몬 스레드");
+
+            // CPU
+            sb.append("\n### CPU\n");
+            appendMetricValue(sb, serviceUrl, "process.cpu.usage", null, "프로세스 CPU");
+            appendMetricValue(sb, serviceUrl, "system.cpu.usage", null, "시스템 CPU");
+
+            // Uptime
+            sb.append("\n### 가동 시간\n");
+            appendMetricValue(sb, serviceUrl, "process.uptime", null, "업타임");
+
+            return sb.toString();
+
+        } catch (Exception e) {
+            return formatError("JVM 메트릭 조회", serviceUrl, e);
+        }
+    }
+
+    public String getHttpMetrics(String serviceUrl) {
+        try {
+            StringBuilder sb = new StringBuilder();
+            sb.append("## HTTP 메트릭 — ").append(serviceUrl).append("\n\n");
+
+            // Server requests
+            String response = fetchActuator(serviceUrl, "/actuator/metrics/http.server.requests");
+            JsonNode metric = objectMapper.readTree(response);
+
+            JsonNode measurements = metric.path("measurements");
+            if (measurements.isArray()) {
+                sb.append("### 전체 HTTP 요청 통계\n");
+                sb.append("| 통계 | 값 |\n");
+                sb.append("|------|----|\n");
+                for (JsonNode m : measurements) {
+                    String stat = m.path("statistic").asText();
+                    double value = m.path("value").asDouble();
+                    String formatted;
+                    if ("TOTAL_TIME".equals(stat) || "MAX".equals(stat)) {
+                        formatted = String.format("%.3f s", value);
+                    } else {
+                        formatted = String.format("%.0f", value);
+                    }
+                    sb.append(String.format("| %s | %s |\n", stat, formatted));
+                }
+            }
+
+            // Tags breakdown
+            JsonNode tags = metric.path("availableTags");
+            if (tags.isArray()) {
+                for (JsonNode tag : tags) {
+                    if ("uri".equals(tag.path("tag").asText())) {
+                        sb.append("\n### 엔드포인트별 분류\n");
+                        JsonNode uris = tag.path("values");
+                        if (uris.isArray()) {
+                            for (JsonNode uri : uris) {
+                                sb.append("- `").append(uri.asText()).append("`\n");
+                            }
+                        }
+                    }
+                    if ("status".equals(tag.path("tag").asText())) {
+                        sb.append("\n### HTTP 상태 코드\n");
+                        JsonNode statuses = tag.path("values");
+                        if (statuses.isArray()) {
+                            for (JsonNode s : statuses) {
+                                String code = s.asText();
+                                String icon = code.startsWith("2") ? "✅" : code.startsWith("4") ? "⚠️" : "❌";
+                                sb.append("- ").append(icon).append(" ").append(code).append("\n");
+                            }
+                        }
+                    }
+                }
+            }
+
+            return sb.toString();
+
+        } catch (Exception e) {
+            return formatError("HTTP 메트릭 조회", serviceUrl, e);
+        }
+    }
+
+    private void appendMetricValue(StringBuilder sb, String serviceUrl, String metricName, String tagFilter, String label) {
+        try {
+            String path = "/actuator/metrics/" + metricName;
+            if (tagFilter != null) path += "?" + tagFilter;
+            String response = fetchActuator(serviceUrl, path);
+            JsonNode metric = objectMapper.readTree(response);
+
+            JsonNode measurements = metric.path("measurements");
+            if (measurements.isArray()) {
+                for (JsonNode m : measurements) {
+                    double value = m.path("value").asDouble();
+                    String unit = metric.path("baseUnit").asText("");
+
+                    String formatted;
+                    if ("bytes".equals(unit)) {
+                        formatted = formatBytes(value);
+                    } else if ("seconds".equals(unit)) {
+                        formatted = formatDuration(value);
+                    } else if (value < 1.0 && value > 0) {
+                        formatted = String.format("%.2f%%", value * 100);
+                    } else {
+                        formatted = String.format("%.0f", value);
+                    }
+
+                    sb.append("- **").append(label).append("**: ").append(formatted).append("\n");
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            sb.append("- **").append(label).append("**: 조회 실패\n");
+        }
+    }
+
+    private String fetchActuator(String baseUrl, String path) {
+        return webClient.get()
+                .uri(baseUrl + path)
+                .retrieve()
+                .bodyToMono(String.class)
+                .timeout(Duration.ofSeconds(5))
+                .block();
+    }
+
+    private String formatBytes(double bytes) {
+        if (bytes >= 1_073_741_824) return String.format("%.2f GB", bytes / 1_073_741_824);
+        if (bytes >= 1_048_576) return String.format("%.2f MB", bytes / 1_048_576);
+        if (bytes >= 1024) return String.format("%.2f KB", bytes / 1024);
+        return String.format("%.0f B", bytes);
+    }
+
+    private String formatDuration(double seconds) {
+        if (seconds >= 3600) return String.format("%.1f h", seconds / 3600);
+        if (seconds >= 60) return String.format("%.1f m", seconds / 60);
+        if (seconds >= 1) return String.format("%.2f s", seconds);
+        return String.format("%.0f ms", seconds * 1000);
+    }
+
+    private String formatError(String operation, String serviceUrl, Exception e) {
+        log.error("{} 실패 [{}]: {}", operation, serviceUrl, e.getMessage());
+        return String.format("## ❌ %s 실패\n\n- **서비스**: %s\n- **오류**: %s\n\n> 서비스가 실행 중인지, Actuator 엔드포인트가 노출되어 있는지 확인해주세요.",
+                operation, serviceUrl, e.getMessage());
+    }
+}

--- a/tally-mcp-monitor/src/main/java/com/devpulse/mcp/monitor/tools/ServiceMonitorTools.java
+++ b/tally-mcp-monitor/src/main/java/com/devpulse/mcp/monitor/tools/ServiceMonitorTools.java
@@ -1,0 +1,62 @@
+package com.devpulse.mcp.monitor.tools;
+
+import com.devpulse.mcp.monitor.service.ServiceMonitorService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+/**
+ * MCP Server 도구 — 서비스 모니터링
+ * Spring Boot Actuator 기반 헬스체크, 메트릭 조회, JVM/HTTP 모니터링
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ServiceMonitorTools {
+
+    private final ServiceMonitorService serviceMonitorService;
+
+    @Tool(description = "서비스의 헬스체크 상태를 조회합니다. Spring Boot Actuator /health 엔드포인트를 호출하여 서비스 상태와 컴포넌트별 상태를 반환합니다.")
+    public String checkHealth(
+            @ToolParam(description = "서비스 URL (예: http://localhost:8080)") String serviceUrl) {
+        log.info("Tool: check_health url={}", serviceUrl);
+        return serviceMonitorService.checkHealth(serviceUrl);
+    }
+
+    @Tool(description = "서비스의 메트릭을 조회합니다. metricName이 비어있으면 사용 가능한 메트릭 목록을 반환합니다. 특정 메트릭 이름을 지정하면 해당 메트릭의 측정값과 태그를 반환합니다.")
+    public String getMetrics(
+            @ToolParam(description = "서비스 URL (예: http://localhost:8080)") String serviceUrl,
+            @ToolParam(description = "메트릭 이름 (예: jvm.memory.used). 비워두면 전체 목록 반환") String metricName) {
+        log.info("Tool: get_metrics url={} metric={}", serviceUrl, metricName);
+        return serviceMonitorService.getMetrics(serviceUrl, metricName);
+    }
+
+    @Tool(description = "서비스의 기본 정보를 조회합니다. Spring Boot Actuator /info 엔드포인트를 호출하여 빌드 정보, Git 정보 등을 반환합니다.")
+    public String getServiceInfo(
+            @ToolParam(description = "서비스 URL (예: http://localhost:8080)") String serviceUrl) {
+        log.info("Tool: get_service_info url={}", serviceUrl);
+        return serviceMonitorService.getServiceInfo(serviceUrl);
+    }
+
+    @Tool(description = "등록된 모든 서비스의 헬스체크를 한번에 수행합니다. 각 서비스의 상태와 응답 시간을 요약 테이블로 반환합니다.")
+    public String checkAllServices() {
+        log.info("Tool: check_all_services");
+        return serviceMonitorService.checkAllServices();
+    }
+
+    @Tool(description = "서비스의 JVM 메트릭을 조회합니다. 힙/논힙 메모리 사용량, GC 통계, 스레드 수, CPU 사용률, 가동 시간을 반환합니다.")
+    public String getJvmMetrics(
+            @ToolParam(description = "서비스 URL (예: http://localhost:8080)") String serviceUrl) {
+        log.info("Tool: get_jvm_metrics url={}", serviceUrl);
+        return serviceMonitorService.getJvmMetrics(serviceUrl);
+    }
+
+    @Tool(description = "서비스의 HTTP 요청 메트릭을 조회합니다. 전체 요청 수, 응답 시간, 엔드포인트별 분류, HTTP 상태 코드 분포를 반환합니다.")
+    public String getHttpMetrics(
+            @ToolParam(description = "서비스 URL (예: http://localhost:8080)") String serviceUrl) {
+        log.info("Tool: get_http_metrics url={}", serviceUrl);
+        return serviceMonitorService.getHttpMetrics(serviceUrl);
+    }
+}

--- a/tally-mcp-monitor/src/main/resources/application.yml
+++ b/tally-mcp-monitor/src/main/resources/application.yml
@@ -6,10 +6,35 @@ spring:
       server:
         name: tally-mcp-monitor
         version: 3.0.0
+        type: SYNC
+        instructions: "서비스 모니터링 도구를 제공하는 MCP Server입니다. Spring Boot Actuator 기반 헬스체크, 메트릭 조회, JVM/HTTP 모니터링 기능을 지원합니다."
+        capabilities:
+          tool: true
+        sse-message-endpoint: /mcp/messages
+
+# 모니터링 대상 서비스 등록
+monitor:
+  services:
+    - name: tally-agent
+      url: http://localhost:8080
+    - name: tally-mcp-github
+      url: http://localhost:8081
+    - name: tally-mcp-k8s
+      url: http://localhost:8082
 
 server:
   port: 8083
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+  endpoint:
+    health:
+      show-details: always
+
 logging:
   level:
     com.devpulse: DEBUG
+    org.springframework.ai.mcp: DEBUG


### PR DESCRIPTION
## Summary
- **tally-mcp-k8s**: K8s 클러스터 관리 MCP 도구 8개 구현 (Pod/Deployment/Service 조회, 스케일링, 롤링 재시작, 로그 조회, 클러스터 상태)
- **tally-mcp-monitor**: 서비스 모니터링 MCP 도구 6개 구현 (Actuator 헬스체크, 메트릭 조회, JVM/HTTP 통계, 전체 서비스 일괄 헬스체크)
- **tally-agent**: k8s-mcp(8082), monitor-mcp(8083) SSE 연결 추가 + 시스템 프롬프트에 K8s/모니터링 워크플로우 추가
- **K8s 매니페스트**: Namespace, RBAC(ServiceAccount + ClusterRole), Deployment×4, Service×4, ConfigMap, Secret
- **Docker**: Dockerfile 4개 모듈 + Docker Compose 전체 통합 (profile 제거)

## MCP 도구 현황 (총 31개)
| 모듈 | 도구 수 | 카테고리 |
|------|---------|----------|
| tally-mcp-github | 17개 | 레포 분석, 코드 검사, 팀 건강 |
| tally-mcp-k8s | 8개 | Pod, Deployment, Service, 클러스터 |
| tally-mcp-monitor | 6개 | 헬스체크, 메트릭, JVM, HTTP |

## Test plan
- [ ] `./gradlew clean build -x test` 빌드 성공 확인
- [ ] Docker Compose로 전체 서비스 기동 테스트
- [ ] K8s 클러스터 연결 시 도구 동작 확인
- [ ] Actuator 엔드포인트 접근 및 모니터링 도구 테스트

closes #35