### PR TITLE
feat: 차트 시각화 시스템 프롬프트 + OAuth + 조직 API (#43)

### DIFF
--- a/tally-agent/src/main/java/com/devpulse/agent/config/WebConfig.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/config/WebConfig.java
@@ -1,18 +1,24 @@
 package com.devpulse.agent.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 @Configuration
-public class WebConfig implements WebMvcConfigurer {
+public class WebConfig {
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:5173", "http://localhost:3000")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(true);
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.addAllowedOriginPattern("http://localhost:*");
+        config.addAllowedMethod("*");
+        config.addAllowedHeader("*");
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", config);
+        return new CorsFilter(source);
     }
 }

--- a/tally-agent/src/main/java/com/devpulse/agent/controller/AuthController.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.devpulse.agent.controller;
+
+import com.devpulse.agent.service.GitHubOAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final GitHubOAuthService gitHubOAuthService;
+
+    @GetMapping("/github")
+    public Map<String, String> getAuthUrl() {
+        return Map.of("authUrl", gitHubOAuthService.getAuthorizationUrl());
+    }
+
+    @PostMapping("/github/callback")
+    public Map<String, Object> handleCallback(@RequestBody Map<String, String> request) {
+        String code = request.get("code");
+        if (code == null || code.isBlank()) {
+            throw new IllegalArgumentException("Authorization code is required");
+        }
+        return gitHubOAuthService.exchangeCodeForUser(code);
+    }
+}

--- a/tally-agent/src/main/java/com/devpulse/agent/controller/ChatController.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/controller/ChatController.java
@@ -9,24 +9,33 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/chat")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 @CrossOrigin(origins = "*")
 public class ChatController {
 
     private final AgentService agentService;
 
-    @PostMapping
+    @PostMapping("/user/organizations")
+    public List<String> getUserOrganizations(@RequestBody Map<String, String> body) {
+        String githubToken = body.get("githubToken");
+        return agentService.getUserOrganizations(githubToken);
+    }
+
+    @PostMapping("/chat")
     public ChatResponse chat(@Valid @RequestBody ChatRequest request) {
         String conversationId = resolveConversationId(request.getConversationId());
 
         String response = agentService.chat(
                 request.getMessage(),
                 request.getGithubToken(),
-                conversationId
+                conversationId,
+                request.getSelectedOrg()
         );
 
         return ChatResponse.builder()
@@ -35,18 +44,19 @@ public class ChatController {
                 .build();
     }
 
-    @PostMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @PostMapping(value = "/chat/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<String> chatStream(@RequestBody ChatRequest request) {
         String conversationId = resolveConversationId(request.getConversationId());
 
         return agentService.chatStream(
                 request.getMessage(),
                 request.getGithubToken(),
-                conversationId
+                conversationId,
+                request.getSelectedOrg()
         );
     }
 
-    @DeleteMapping("/conversations/{conversationId}")
+    @DeleteMapping("/chat/conversations/{conversationId}")
     public void clearConversation(@PathVariable String conversationId) {
         agentService.clearConversation(conversationId);
     }

--- a/tally-agent/src/main/java/com/devpulse/agent/dto/ChatRequest.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/dto/ChatRequest.java
@@ -12,4 +12,6 @@ public class ChatRequest {
     private String githubToken;
 
     private String conversationId;
+
+    private String selectedOrg;
 }

--- a/tally-agent/src/main/java/com/devpulse/agent/service/AgentService.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/service/AgentService.java
@@ -5,11 +5,18 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.vectorstore.QuestionAnswerAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Service
@@ -60,6 +67,26 @@ public class AgentService {
             4. Use calculateDoraMetrics for overall engineering maturity assessment
             5. Generate getRecentActivity or generateSprintReport for period summaries
 
+            CRITICAL — TOOL PARAMETER RULES:
+            - diagnoseBusFactor, diagnoseReviewBottleneck, diagnoseBurnoutRisk, calculateDoraMetrics,
+              getRecentActivity, generateSprintReport, getCommitQuality, getPrQuality, analyzeRepo
+              ALL require TWO parameters: owner (organization name) AND repo (repository name).
+            - "repo" must be a SPECIFIC REPOSITORY NAME like "Tally-BE", NOT an organization name.
+            - NEVER pass an organization name as the "repo" parameter. This WILL cause an error.
+
+            MANDATORY WORKFLOW when user mentions an organization (not a specific repo):
+            1. FIRST call listOrgRepos to get the list of repositories in that organization
+            2. THEN pick the main repository (prefer -BE over -FE, or the largest one)
+            3. THEN call the analysis tool with owner=orgName AND repo=repoName
+            4. Tell the user which repo you analyzed
+
+            Example: User says "Farm-On bus factor 분석해줘"
+            → Step 1: call listOrgRepos(token, "Farm-On") → gets ["FE", "BE"]
+            → Step 2: pick "BE" as main repo
+            → Step 3: call diagnoseBusFactor(token, "Farm-On", "BE")
+
+            If the user's GitHub Context below already lists repos for that org, you may skip listOrgRepos.
+
             ### Kubernetes Cluster Management
             - listPods: List Pods in a namespace (status, ready, restarts, node)
             - getPodDetails: Get detailed Pod info (containers, resources, conditions)
@@ -86,6 +113,85 @@ public class AgentService {
             4. Use scaleDeployment/restartDeployment for remediation
             5. Use checkAllServices to verify service health after changes
 
+            ## Response Formatting Rules
+            - Use **bold** for key metrics and important values, not headings.
+            - Use `---` horizontal rules to separate major sections for visual breathing room.
+            - Use bullet points with proper line breaks between groups.
+            - Add an empty line between each section for readability.
+            - Keep each bullet point concise — one metric per line.
+            - Start with a one-line summary, then details.
+            - Use emoji sparingly for section markers (e.g. 🔍 진단 결과, ⚠️ 주의, ✅ 양호, 💡 제안).
+            - Do NOT use ### or ## headings in responses — use **bold text** instead.
+            - Example format:
+              **Bus Factor** 🔍
+              - Bus Factor: **2** (주의 — 소수 인원에 집중)
+              - @user1: 48% / @user2: 21% / @user3: 12%
+
+              ---
+
+              **번아웃 위험** ⚠️
+              - @user1: 야간 50%, 주말 25% → 조절 필요
+
+            ## Chart Rendering
+            When presenting analysis results, ALWAYS include a chart data block for visual rendering.
+            After the text summary, output a line starting with the exact chart prefix followed by a JSON object on the SAME line.
+            Rules for ALL charts:
+            - Start line with the prefix followed by colon, then JSON: PREFIX_CHART:{json}
+            - NEVER write the prefix without the JSON data. The prefix alone is meaningless.
+            - The entire JSON must be on that SAME line (no line breaks inside the JSON)
+            - All fields shown in the example are REQUIRED — fill them with actual values from tool results
+            - Place AFTER the text summary
+
+            ### DORA Metrics Chart
+            Prefix: DORA_CHART:
+            DORA_CHART:{"repo":"owner/repo","overall":"Medium","metrics":[{"name":"배포 빈도","value":6.3,"grade":"High","display":"6.3회/주","elite":"하루 여러 번"},{"name":"리드 타임","value":3.8,"grade":"Elite","display":"3.8시간","elite":"< 1시간"},{"name":"변경 실패율","value":11.7,"grade":"Medium","display":"11.7%","elite":"< 5%"},{"name":"MTTR","value":9.9,"grade":"High","display":"9.9시간","elite":"< 1시간"}]}
+            - grade: Elite, High, Medium, Low, N/A
+            - Always include all 4 metrics
+
+            ### Bus Factor Chart
+            Prefix: BUSFACTOR_CHART:
+            When presenting diagnoseBusFactor results, output:
+            BUSFACTOR_CHART:{"repo":"owner/repo","busFactor":2,"contributors":[{"name":"@user1","commits":120,"percentage":48.0},{"name":"@user2","commits":53,"percentage":21.2},{"name":"@user3","commits":30,"percentage":12.0},{"name":"Others","commits":47,"percentage":18.8}]}
+            - busFactor: integer 1-5
+            - Include top contributors + "Others" if needed
+            - percentage values must sum to ~100
+
+            ### Burnout Risk Chart
+            Prefix: BURNOUT_CHART:
+            When presenting diagnoseBurnoutRisk results, output:
+            BURNOUT_CHART:{"repo":"owner/repo","contributors":[{"name":"@user1","risk":"높음","nightPercent":50.0,"weekendPercent":25.0,"hourly":[0,0,1,2,0,0,0,0,5,8,12,10,8,7,6,5,4,3,8,10,12,8,5,2]},{"name":"@user2","risk":"정상","nightPercent":5.0,"weekendPercent":8.0,"hourly":[0,0,0,0,0,0,0,1,5,10,15,12,8,10,12,10,8,5,2,0,0,0,0,0]}]}
+            - risk: "높음", "주의", or "정상"
+            - hourly: array of exactly 24 integers (index 0 = 0시, index 23 = 23시), each value is the commit count for that hour
+            - Convert the time distribution data from the tool result into numeric hourly array
+
+            ### Commit Quality Chart
+            Prefix: COMMITQUALITY_CHART:
+            When presenting getCommitQuality results, output:
+            COMMITQUALITY_CHART:{"repo":"owner/repo","grade":"A","totalCommits":78,"conventionalRate":89.7,"types":[{"name":"feat","count":25},{"name":"fix","count":18},{"name":"refactor","count":12},{"name":"docs","count":8},{"name":"test","count":5},{"name":"other","count":10}]}
+            - grade: A, B, C, D, F
+            - types: commit type distribution from the tool result
+
+            ### Review Bottleneck Chart
+            Prefix: REVIEWBOTTLENECK_CHART:
+            When presenting diagnoseReviewBottleneck results, output:
+            REVIEWBOTTLENECK_CHART:{"repo":"owner/repo","avgReviewTime":"18.5시간","avgMergeTime":"24.2시간","pendingPRs":3,"reviewers":[{"name":"@user1","reviews":15,"avgResponseHours":4.2},{"name":"@user2","reviews":10,"avgResponseHours":12.5}]}
+            - avgResponseHours: numeric value in hours
+
+            ### Compare Repos Chart
+            Prefix: COMPAREREPOS_CHART:
+            When presenting compareRepos results or comparing multiple repositories, you MUST output the chart JSON.
+            Do NOT write just "COMPAREREPOS_CHART" alone — the JSON data MUST follow on the SAME line.
+            COMPAREREPOS_CHART:{"username":"user","repos":[{"name":"repo1","commits":48,"prs":12,"commitGrade":"B","conventionalRate":85.0,"prMergeRate":83.3},{"name":"repo2","commits":72,"prs":18,"commitGrade":"A","conventionalRate":92.5,"prMergeRate":88.9}]}
+            - Fill in actual values from the tool results. Every field is REQUIRED.
+            - commitGrade and conventionalRate come from getCommitQuality results for each repo.
+            - prMergeRate comes from compareRepos or getPrQuality results.
+
+            ### Role Distribution Chart
+            Prefix: ROLEDISTR_CHART:
+            When presenting analyzeRepo results, output:
+            ROLEDISTR_CHART:{"repo":"owner/repo","username":"user","roles":[{"name":"feature","commits":25,"percentage":45.5},{"name":"bugfix","commits":12,"percentage":21.8},{"name":"refactoring","commits":8,"percentage":14.5},{"name":"documentation","commits":6,"percentage":10.9},{"name":"infrastructure","commits":4,"percentage":7.3}]}
+            - role names: feature, bugfix, refactoring, documentation, infrastructure
+
             ## Guidelines
             - Provide data-driven insights backed by specific evidence from the tools.
             - When analyzing, start with an overview then drill into specifics.
@@ -98,11 +204,26 @@ public class AgentService {
 
     private final ChatClient chatClient;
     private final ChatMemory chatMemory;
+    private final ToolCallback[] allCallbacks;
+    private final Map<String, String> userContextCache = new ConcurrentHashMap<>();
 
-    public AgentService(ChatClient.Builder chatClientBuilder, ChatMemory chatMemory, VectorStore vectorStore) {
+    public AgentService(ChatClient.Builder chatClientBuilder, ChatMemory chatMemory,
+                        VectorStore vectorStore, List<ToolCallbackProvider> toolCallbackProviders) {
         this.chatMemory = chatMemory;
+        log.info("Number of ToolCallbackProviders injected: {}", toolCallbackProviders.size());
+        for (ToolCallbackProvider provider : toolCallbackProviders) {
+            log.info("  Provider class: {}", provider.getClass().getName());
+            ToolCallback[] cbs = provider.getToolCallbacks();
+            log.info("  Provider returned {} callbacks", cbs.length);
+        }
+        this.allCallbacks = toolCallbackProviders.stream()
+                .flatMap(provider -> Arrays.stream(provider.getToolCallbacks()))
+                .toArray(ToolCallback[]::new);
+        log.info("Registering {} MCP tool callbacks with ChatClient", allCallbacks.length);
+        Arrays.stream(allCallbacks).forEach(t -> log.info("  Tool: {}", t.getToolDefinition().name()));
         this.chatClient = chatClientBuilder
                 .defaultSystem(BASE_SYSTEM_PROMPT)
+                .defaultToolCallbacks(allCallbacks)
                 .defaultAdvisors(
                         MessageChatMemoryAdvisor.builder(chatMemory).build(),
                         QuestionAnswerAdvisor.builder(vectorStore).build()
@@ -110,11 +231,11 @@ public class AgentService {
                 .build();
     }
 
-    public String chat(String message, String githubToken, String conversationId) {
+    public String chat(String message, String githubToken, String conversationId, String selectedOrg) {
         conversationId = resolveConversationId(conversationId);
         log.info("Chat request [conversationId={}]: {}", conversationId, message);
 
-        String systemPrompt = buildSystemPrompt(githubToken);
+        String systemPrompt = buildSystemPrompt(githubToken, selectedOrg);
         String cid = conversationId;
 
         return chatClient.prompt()
@@ -125,11 +246,11 @@ public class AgentService {
                 .content();
     }
 
-    public Flux<String> chatStream(String message, String githubToken, String conversationId) {
+    public Flux<String> chatStream(String message, String githubToken, String conversationId, String selectedOrg) {
         conversationId = resolveConversationId(conversationId);
         log.info("Stream chat request [conversationId={}]: {}", conversationId, message);
 
-        String systemPrompt = buildSystemPrompt(githubToken);
+        String systemPrompt = buildSystemPrompt(githubToken, selectedOrg);
         String cid = conversationId;
 
         return chatClient.prompt()
@@ -138,6 +259,49 @@ public class AgentService {
                 .advisors(a -> a.param(ChatMemory.CONVERSATION_ID, cid))
                 .stream()
                 .content();
+    }
+
+    public List<String> getUserOrganizations(String githubToken) {
+        // Direct GitHub REST API call (bypasses MCP for reliability)
+        try {
+            String response = WebClient.builder().build()
+                    .get()
+                    .uri("https://api.github.com/user/orgs?per_page=100")
+                    .header("Authorization", "Bearer " + githubToken)
+                    .header("Accept", "application/json")
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            com.fasterxml.jackson.databind.JsonNode orgs = new com.fasterxml.jackson.databind.ObjectMapper().readTree(response);
+            List<String> result = new java.util.ArrayList<>();
+            for (com.fasterxml.jackson.databind.JsonNode org : orgs) {
+                if (org.has("login")) {
+                    result.add(org.get("login").asText());
+                }
+            }
+            log.info("Fetched {} organizations via REST API", result.size());
+            return result;
+        } catch (Exception e) {
+            log.warn("Failed to fetch organizations via REST: {}", e.getMessage());
+        }
+
+        // Fallback: try MCP tool
+        String tokenJson = "{\"token\":\"" + githubToken.replace("\"", "\\\"") + "\"}";
+        try {
+            ToolCallback listOrgs = findTool("listOrganizations");
+            if (listOrgs != null) {
+                String result = listOrgs.call(tokenJson);
+                return Arrays.stream(result.split("\n"))
+                        .filter(line -> line.startsWith("- "))
+                        .map(line -> line.substring(2).split(" — ")[0].trim())
+                        .filter(name -> !name.isEmpty())
+                        .toList();
+            }
+        } catch (Exception e) {
+            log.warn("Failed to fetch organizations via MCP: {}", e.getMessage());
+        }
+        return List.of();
     }
 
     public void clearConversation(String conversationId) {
@@ -151,16 +315,71 @@ public class AgentService {
                 : UUID.randomUUID().toString();
     }
 
-    private String buildSystemPrompt(String githubToken) {
+    private String buildSystemPrompt(String githubToken, String selectedOrg) {
         if (githubToken == null || githubToken.isBlank()) {
             return BASE_SYSTEM_PROMPT;
         }
+
+        String userContext = userContextCache.computeIfAbsent(githubToken, this::fetchUserContext);
+
+        String orgContext = (selectedOrg != null && !selectedOrg.isBlank())
+                ? "\n\n## Selected Organization\nThe user has selected **%s** as their active organization. When they say '우리 팀', 'our team', or ask about team/repo analysis without specifying, ALWAYS use **%s** as the owner. Do NOT analyze other organizations unless explicitly asked.".formatted(selectedOrg, selectedOrg)
+                : "";
+
         return BASE_SYSTEM_PROMPT + """
 
                 ## GitHub Authentication
                 The user has provided a GitHub access token.
                 Use this token as the 'token' parameter for ALL GitHub tool calls: %s
                 Never reveal this token in your responses.
-                """.formatted(githubToken);
+
+                ## User's GitHub Context (auto-discovered)
+                %s
+
+                ## Context Usage Rules
+                - When the user says "우리 팀" or "our team", use the selected organization context.
+                - Do NOT ask the user which org or repo to analyze — use the selected organization.
+                - Always specify the exact owner/repo when calling tools.
+                """.formatted(githubToken, userContext) + orgContext;
+    }
+
+    private String fetchUserContext(String githubToken) {
+        StringBuilder ctx = new StringBuilder();
+        String tokenJson = "{\"token\":\"" + githubToken.replace("\"", "\\\"") + "\"}";
+
+        // Fetch organizations
+        try {
+            ToolCallback listOrgs = findTool("listOrganizations");
+            if (listOrgs != null) {
+                String orgs = listOrgs.call(tokenJson);
+                ctx.append("### Organizations\n").append(orgs).append("\n\n");
+                log.info("Auto-discovered orgs: {}", orgs);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to auto-discover organizations: {}", e.getMessage());
+            ctx.append("### Organizations\n(조회 실패)\n\n");
+        }
+
+        // Fetch repositories
+        try {
+            ToolCallback listRepos = findTool("listRepos");
+            if (listRepos != null) {
+                String repos = listRepos.call(tokenJson);
+                ctx.append("### Repositories\n").append(repos).append("\n");
+                log.info("Auto-discovered repos: {}", repos);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to auto-discover repositories: {}", e.getMessage());
+            ctx.append("### Repositories\n(조회 실패)\n");
+        }
+
+        return ctx.toString();
+    }
+
+    private ToolCallback findTool(String toolNameSuffix) {
+        return Arrays.stream(allCallbacks)
+                .filter(t -> t.getToolDefinition().name().endsWith(toolNameSuffix))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/tally-agent/src/main/java/com/devpulse/agent/service/GitHubOAuthService.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/service/GitHubOAuthService.java
@@ -1,0 +1,87 @@
+package com.devpulse.agent.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class GitHubOAuthService {
+
+    @Value("${github.oauth.client-id:}")
+    private String clientId;
+
+    @Value("${github.oauth.client-secret:}")
+    private String clientSecret;
+
+    @Value("${github.oauth.redirect-uri:http://localhost:5173/auth/callback}")
+    private String redirectUri;
+
+    private final WebClient webClient = WebClient.builder().build();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public String getAuthorizationUrl() {
+        return "https://github.com/login/oauth/authorize"
+                + "?client_id=" + clientId
+                + "&redirect_uri=" + redirectUri
+                + "&scope=repo,read:org,read:user";
+    }
+
+    public Map<String, Object> exchangeCodeForUser(String code) {
+        // Exchange code for access token
+        String tokenResponse = webClient.post()
+                .uri("https://github.com/login/oauth/access_token")
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .bodyValue(Map.of(
+                        "client_id", clientId,
+                        "client_secret", clientSecret,
+                        "code", code,
+                        "redirect_uri", redirectUri
+                ))
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        try {
+            JsonNode tokenNode = objectMapper.readTree(tokenResponse);
+
+            if (tokenNode.has("error")) {
+                throw new RuntimeException("GitHub OAuth error: " + tokenNode.get("error_description").asText());
+            }
+
+            String accessToken = tokenNode.get("access_token").asText();
+
+            // Fetch user info
+            String userResponse = webClient.get()
+                    .uri("https://api.github.com/user")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            JsonNode userNode = objectMapper.readTree(userResponse);
+
+            Map<String, Object> result = new HashMap<>();
+            result.put("accessToken", accessToken);
+            result.put("username", userNode.get("login").asText());
+            result.put("avatarUrl", userNode.get("avatar_url").asText());
+            result.put("id", String.valueOf(userNode.get("id").asLong()));
+
+            log.info("GitHub OAuth login: {}", result.get("username"));
+            return result;
+
+        } catch (Exception e) {
+            log.error("GitHub OAuth failed: {}", e.getMessage());
+            throw new RuntimeException("GitHub OAuth failed: " + e.getMessage());
+        }
+    }
+}

--- a/tally-agent/src/main/resources/application.yml
+++ b/tally-agent/src/main/resources/application.yml
@@ -18,14 +18,22 @@ spring:
         version: 3.0.0
         request-timeout: 30s
         type: SYNC
+        toolcallback:
+          enabled: true
         sse:
           connections:
             github-mcp:
               url: http://localhost:8081
-            k8s-mcp:
-              url: http://localhost:8082
-            monitor-mcp:
-              url: http://localhost:8083
+#            k8s-mcp:
+#              url: http://localhost:8082
+#            monitor-mcp:
+#              url: http://localhost:8083
+
+github:
+  oauth:
+    client-id: ${GITHUB_OAUTH_CLIENT_ID:}
+    client-secret: ${GITHUB_OAUTH_CLIENT_SECRET:}
+    redirect-uri: ${GITHUB_OAUTH_REDIRECT_URI:http://localhost:5174/auth/callback}
 
 server:
   port: 8080

--- a/tally-mcp-github/src/main/java/com/devpulse/mcp/github/config/ToolCallbackConfig.java
+++ b/tally-mcp-github/src/main/java/com/devpulse/mcp/github/config/ToolCallbackConfig.java
@@ -1,0 +1,28 @@
+package com.devpulse.mcp.github.config;
+
+import com.devpulse.mcp.github.tools.CodeInspectionTools;
+import com.devpulse.mcp.github.tools.RepoAnalysisTools;
+import com.devpulse.mcp.github.tools.TeamHealthTools;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.method.MethodToolCallbackProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ToolCallbackConfig {
+
+    @Bean
+    ToolCallbackProvider repoAnalysisToolCallbackProvider(RepoAnalysisTools tools) {
+        return MethodToolCallbackProvider.builder().toolObjects(tools).build();
+    }
+
+    @Bean
+    ToolCallbackProvider codeInspectionToolCallbackProvider(CodeInspectionTools tools) {
+        return MethodToolCallbackProvider.builder().toolObjects(tools).build();
+    }
+
+    @Bean
+    ToolCallbackProvider teamHealthToolCallbackProvider(TeamHealthTools tools) {
+        return MethodToolCallbackProvider.builder().toolObjects(tools).build();
+    }
+}

--- a/tally-mcp-github/src/main/java/com/devpulse/mcp/github/tools/CodeInspectionTools.java
+++ b/tally-mcp-github/src/main/java/com/devpulse/mcp/github/tools/CodeInspectionTools.java
@@ -25,7 +25,12 @@ public class CodeInspectionTools {
             @ToolParam(description = "레포지토리 이름") String repo,
             @ToolParam(description = "PR 번호") int prNumber) {
         log.info("Tool: get_pr_diff {}/{} #{}", owner, repo, prNumber);
-        return codeInspectionService.analyzePrDiff(token, owner, repo, prNumber);
+        try {
+            return codeInspectionService.analyzePrDiff(token, owner, repo, prNumber);
+        } catch (Exception e) {
+            log.error("Tool: get_pr_diff {}/{} #{} failed", owner, repo, prNumber, e);
+            return String.format("Error: %s/%s PR #%d diff 조회 실패 — %s", owner, repo, prNumber, e.getMessage());
+        }
     }
 
     @Tool(description = "레포지토리의 버그 핫스팟을 분석합니다. fix 커밋이 자주 발생하는 파일을 위험도별로 분류합니다. 코드 품질 개선 우선순위 결정에 활용합니다.")
@@ -34,7 +39,12 @@ public class CodeInspectionTools {
             @ToolParam(description = "레포지토리 소유자") String owner,
             @ToolParam(description = "레포지토리 이름") String repo) {
         log.info("Tool: get_file_bug_history {}/{}", owner, repo);
-        return codeInspectionService.analyzeFileBugHistory(token, owner, repo);
+        try {
+            return codeInspectionService.analyzeFileBugHistory(token, owner, repo);
+        } catch (Exception e) {
+            log.error("Tool: get_file_bug_history {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s 버그 핫스팟 분석 실패 — %s", owner, repo, e.getMessage());
+        }
     }
 
     @Tool(description = "특정 파일의 기여자를 분석합니다. 누가 얼마나 기여했는지, Bus Factor 경고를 포함합니다. 코드 리뷰어 지정이나 지식 공유 필요성 판단에 활용합니다.")
@@ -44,7 +54,12 @@ public class CodeInspectionTools {
             @ToolParam(description = "레포지토리 이름") String repo,
             @ToolParam(description = "파일 경로 (예: src/main/java/com/example/Service.java)") String path) {
         log.info("Tool: get_file_contributors {}/{} path={}", owner, repo, path);
-        return codeInspectionService.analyzeFileContributors(token, owner, repo, path);
+        try {
+            return codeInspectionService.analyzeFileContributors(token, owner, repo, path);
+        } catch (Exception e) {
+            log.error("Tool: get_file_contributors {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s 파일 기여자 분석 실패 — %s", owner, repo, e.getMessage());
+        }
     }
 
     @Tool(description = "레포지토리의 PR 리뷰 히스토리를 분석합니다. 리뷰 커버리지, 리뷰어별 통계, 평균 리뷰 시간, 리뷰 품질 등급(A-F)을 반환합니다.")
@@ -53,6 +68,11 @@ public class CodeInspectionTools {
             @ToolParam(description = "레포지토리 소유자") String owner,
             @ToolParam(description = "레포지토리 이름") String repo) {
         log.info("Tool: get_review_history {}/{}", owner, repo);
-        return codeInspectionService.analyzeReviewHistory(token, owner, repo);
+        try {
+            return codeInspectionService.analyzeReviewHistory(token, owner, repo);
+        } catch (Exception e) {
+            log.error("Tool: get_review_history {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s 리뷰 히스토리 분석 실패 — %s", owner, repo, e.getMessage());
+        }
     }
 }

--- a/tally-mcp-github/src/main/java/com/devpulse/mcp/github/tools/RepoAnalysisTools.java
+++ b/tally-mcp-github/src/main/java/com/devpulse/mcp/github/tools/RepoAnalysisTools.java
@@ -34,14 +34,19 @@ public class RepoAnalysisTools {
     public String listRepos(
             @ToolParam(description = "GitHub 액세스 토큰") String token) {
         log.info("Tool: list_repos");
-        List<GitHubRepository> repos = graphQLService.getUserRepositories(token);
+        try {
+            List<GitHubRepository> repos = graphQLService.getUserRepositories(token);
 
-        return repos.stream()
-                .map(r -> String.format("- %s (%s) %s",
-                        r.getFullName(),
-                        r.getIsPrivate() ? "private" : "public",
-                        r.getDescription() != null ? r.getDescription() : ""))
-                .collect(Collectors.joining("\n"));
+            return repos.stream()
+                    .map(r -> String.format("- %s (%s) %s",
+                            r.getFullName(),
+                            r.getIsPrivate() ? "private" : "public",
+                            r.getDescription() != null ? r.getDescription() : ""))
+                    .collect(Collectors.joining("\n"));
+        } catch (Exception e) {
+            log.error("Tool: list_repos failed", e);
+            return "Error: 레포지토리 목록 조회 실패 — " + e.getMessage();
+        }
     }
 
     @Tool(description = "특정 레포지토리의 기여도를 분석합니다. 커밋 수, 기여 비율, PR, Issue, 역할 분석 결과를 반환합니다.")
@@ -51,33 +56,38 @@ public class RepoAnalysisTools {
             @ToolParam(description = "레포지토리 이름 (예: Tally-BE)") String repo,
             @ToolParam(description = "분석 대상 GitHub 사용자명") String username) {
         log.info("Tool: analyze_repo {}/{} for {}", owner, repo, username);
-        ContributionStats stats = contributionService.analyzeContribution(token, owner, repo, username);
+        try {
+            ContributionStats stats = contributionService.analyzeContribution(token, owner, repo, username);
 
-        StringBuilder sb = new StringBuilder();
-        sb.append(String.format("## %s/%s 기여도 분석 — %s\n\n", owner, repo, username));
-        sb.append(String.format("- 총 커밋: %d개\n", stats.getTotalCommits()));
-        sb.append(String.format("- 내 커밋: %d개 (%.1f%%)\n", stats.getUserCommits(), stats.getCommitPercentage()));
-        sb.append(String.format("- 활동 기간: %s ~ %s\n", stats.getFirstCommitDate(), stats.getLastCommitDate()));
-        sb.append(String.format("- PR: %d개\n", stats.getPullRequests() != null ? stats.getPullRequests().size() : 0));
-        sb.append(String.format("- Issue: %d개\n", stats.getIssues() != null ? stats.getIssues().size() : 0));
+            StringBuilder sb = new StringBuilder();
+            sb.append(String.format("## %s/%s 기여도 분석 — %s\n\n", owner, repo, username));
+            sb.append(String.format("- 총 커밋: %d개\n", stats.getTotalCommits()));
+            sb.append(String.format("- 내 커밋: %d개 (%.1f%%)\n", stats.getUserCommits(), stats.getCommitPercentage()));
+            sb.append(String.format("- 활동 기간: %s ~ %s\n", stats.getFirstCommitDate(), stats.getLastCommitDate()));
+            sb.append(String.format("- PR: %d개\n", stats.getPullRequests() != null ? stats.getPullRequests().size() : 0));
+            sb.append(String.format("- Issue: %d개\n", stats.getIssues() != null ? stats.getIssues().size() : 0));
 
-        if (stats.getRoleDistribution() != null && !stats.getRoleDistribution().isEmpty()) {
-            sb.append("\n### 역할 분포\n");
-            stats.getRoleDistribution().entrySet().stream()
-                    .sorted((a, b) -> Double.compare(b.getValue().getPercentage(), a.getValue().getPercentage()))
-                    .forEach(e -> sb.append(String.format("- %s: %.1f%% (%d커밋)\n",
-                            e.getKey(), e.getValue().getPercentage(), e.getValue().getCommitCount())));
+            if (stats.getRoleDistribution() != null && !stats.getRoleDistribution().isEmpty()) {
+                sb.append("\n### 역할 분포\n");
+                stats.getRoleDistribution().entrySet().stream()
+                        .sorted((a, b) -> Double.compare(b.getValue().getPercentage(), a.getValue().getPercentage()))
+                        .forEach(e -> sb.append(String.format("- %s: %.1f%% (%d커밋)\n",
+                                e.getKey(), e.getValue().getPercentage(), e.getValue().getCommitCount())));
+            }
+
+            if (stats.getLanguageDistribution() != null && !stats.getLanguageDistribution().isEmpty()) {
+                sb.append("\n### 언어 분포\n");
+                stats.getLanguageDistribution().entrySet().stream()
+                        .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                        .limit(5)
+                        .forEach(e -> sb.append(String.format("- %s: %,d bytes\n", e.getKey(), e.getValue())));
+            }
+
+            return sb.toString();
+        } catch (Exception e) {
+            log.error("Tool: analyze_repo {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s 기여도 분석 실패 — %s", owner, repo, e.getMessage());
         }
-
-        if (stats.getLanguageDistribution() != null && !stats.getLanguageDistribution().isEmpty()) {
-            sb.append("\n### 언어 분포\n");
-            stats.getLanguageDistribution().entrySet().stream()
-                    .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
-                    .limit(5)
-                    .forEach(e -> sb.append(String.format("- %s: %,d bytes\n", e.getKey(), e.getValue())));
-        }
-
-        return sb.toString();
     }
 
     @Tool(description = "레포지토리의 커밋 품질을 분석합니다. Conventional Commits 준수율, 커밋 타입 분포, 품질 등급(A-F)을 반환합니다.")
@@ -86,25 +96,29 @@ public class RepoAnalysisTools {
             @ToolParam(description = "레포지토리 소유자") String owner,
             @ToolParam(description = "레포지토리 이름") String repo) {
         log.info("Tool: get_commit_quality {}/{}", owner, repo);
+        try {
+            GraphQLGitHubService.RepositoryData repoData = graphQLService.getRepositoryAnalysis(token, owner, repo);
+            CommitQualityMetrics metrics = qualityService.analyzeCommitQuality(repoData.getCommits());
 
-        GraphQLGitHubService.RepositoryData repoData = graphQLService.getRepositoryAnalysis(token, owner, repo);
-        CommitQualityMetrics metrics = qualityService.analyzeCommitQuality(repoData.getCommits());
+            StringBuilder sb = new StringBuilder();
+            sb.append(String.format("## %s/%s 커밋 품질 분석\n\n", owner, repo));
+            sb.append(String.format("- 품질 등급: **%s**\n", metrics.getQualityGrade()));
+            sb.append(String.format("- 총 커밋: %d개\n", metrics.getTotalCommits()));
+            sb.append(String.format("- Conventional Commits 준수: %d/%d (%.1f%%)\n",
+                    metrics.getConventionalCommits(), metrics.getTotalCommits(), metrics.getConventionalCommitRate()));
 
-        StringBuilder sb = new StringBuilder();
-        sb.append(String.format("## %s/%s 커밋 품질 분석\n\n", owner, repo));
-        sb.append(String.format("- 품질 등급: **%s**\n", metrics.getQualityGrade()));
-        sb.append(String.format("- 총 커밋: %d개\n", metrics.getTotalCommits()));
-        sb.append(String.format("- Conventional Commits 준수: %d/%d (%.1f%%)\n",
-                metrics.getConventionalCommits(), metrics.getTotalCommits(), metrics.getConventionalCommitRate()));
+            if (metrics.getCommitTypeDistribution() != null && !metrics.getCommitTypeDistribution().isEmpty()) {
+                sb.append("\n### 커밋 타입 분포\n");
+                metrics.getCommitTypeDistribution().entrySet().stream()
+                        .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                        .forEach(e -> sb.append(String.format("- %s: %d개\n", e.getKey(), e.getValue())));
+            }
 
-        if (metrics.getCommitTypeDistribution() != null && !metrics.getCommitTypeDistribution().isEmpty()) {
-            sb.append("\n### 커밋 타입 분포\n");
-            metrics.getCommitTypeDistribution().entrySet().stream()
-                    .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
-                    .forEach(e -> sb.append(String.format("- %s: %d개\n", e.getKey(), e.getValue())));
+            return sb.toString();
+        } catch (Exception e) {
+            log.error("Tool: get_commit_quality {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s 커밋 품질 분석 실패 — %s", owner, repo, e.getMessage());
         }
-
-        return sb.toString();
     }
 
     @Tool(description = "레포지토리의 PR 품질을 분석합니다. 머지율, 평균 리뷰 시간, 품질 등급(A-F)을 반환합니다.")
@@ -113,20 +127,24 @@ public class RepoAnalysisTools {
             @ToolParam(description = "레포지토리 소유자") String owner,
             @ToolParam(description = "레포지토리 이름") String repo) {
         log.info("Tool: get_pr_quality {}/{}", owner, repo);
+        try {
+            GraphQLGitHubService.RepositoryData repoData = graphQLService.getRepositoryAnalysis(token, owner, repo);
+            PRQualityMetrics metrics = qualityService.analyzePRQuality(repoData.getPullRequests());
 
-        GraphQLGitHubService.RepositoryData repoData = graphQLService.getRepositoryAnalysis(token, owner, repo);
-        PRQualityMetrics metrics = qualityService.analyzePRQuality(repoData.getPullRequests());
+            StringBuilder sb = new StringBuilder();
+            sb.append(String.format("## %s/%s PR 품질 분석\n\n", owner, repo));
+            sb.append(String.format("- 품질 등급: **%s**\n", metrics.getQualityGrade()));
+            sb.append(String.format("- 총 PR: %d개\n", metrics.getTotalPRs()));
+            sb.append(String.format("- 머지율: %.1f%% (%d merged / %d closed / %d open)\n",
+                    metrics.getMergeRate(), metrics.getMergedPRs(),
+                    metrics.getClosedWithoutMergePRs(), metrics.getOpenPRs()));
+            sb.append(String.format("- 평균 리뷰 시간: %.1f시간\n", metrics.getAverageReviewTimeHours()));
 
-        StringBuilder sb = new StringBuilder();
-        sb.append(String.format("## %s/%s PR 품질 분석\n\n", owner, repo));
-        sb.append(String.format("- 품질 등급: **%s**\n", metrics.getQualityGrade()));
-        sb.append(String.format("- 총 PR: %d개\n", metrics.getTotalPRs()));
-        sb.append(String.format("- 머지율: %.1f%% (%d merged / %d closed / %d open)\n",
-                metrics.getMergeRate(), metrics.getMergedPRs(),
-                metrics.getClosedWithoutMergePRs(), metrics.getOpenPRs()));
-        sb.append(String.format("- 평균 리뷰 시간: %.1f시간\n", metrics.getAverageReviewTimeHours()));
-
-        return sb.toString();
+            return sb.toString();
+        } catch (Exception e) {
+            log.error("Tool: get_pr_quality {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s PR 품질 분석 실패 — %s", owner, repo, e.getMessage());
+        }
     }
 
     @Tool(description = "조직(Organization)의 전체 레포지토리 기여도를 분석합니다. 팀원별 기여도, 레포별 통계를 반환합니다.")
@@ -135,31 +153,35 @@ public class RepoAnalysisTools {
             @ToolParam(description = "조직 이름 (예: Tally-lab)") String orgName,
             @ToolParam(description = "분석 대상 사용자명") String username) {
         log.info("Tool: get_org_stats {} for {}", orgName, username);
+        try {
+            OrganizationStats stats = contributionService.analyzeOrganization(token, orgName, username);
 
-        OrganizationStats stats = contributionService.analyzeOrganization(token, orgName, username);
+            StringBuilder sb = new StringBuilder();
+            sb.append(String.format("## %s 조직 분석 — %s\n\n", orgName, username));
+            sb.append(String.format("- 레포지토리: %d개\n", stats.getTotalRepositories()));
+            sb.append(String.format("- 총 커밋: %d개 / 내 커밋: %d개 (%.1f%%)\n",
+                    stats.getTotalCommits(), stats.getUserCommits(), stats.getContributionPercentage()));
 
-        StringBuilder sb = new StringBuilder();
-        sb.append(String.format("## %s 조직 분석 — %s\n\n", orgName, username));
-        sb.append(String.format("- 레포지토리: %d개\n", stats.getTotalRepositories()));
-        sb.append(String.format("- 총 커밋: %d개 / 내 커밋: %d개 (%.1f%%)\n",
-                stats.getTotalCommits(), stats.getUserCommits(), stats.getContributionPercentage()));
+            if (stats.getRepositories() != null && !stats.getRepositories().isEmpty()) {
+                sb.append("\n### 레포별 기여도\n");
+                stats.getRepositories().stream()
+                        .sorted((a, b) -> Integer.compare(b.getUserCommits(), a.getUserCommits()))
+                        .forEach(r -> sb.append(String.format("- %s: %d/%d (%.1f%%)\n",
+                                r.getName(), r.getUserCommits(), r.getTotalCommits(), r.getContributionPercentage())));
+            }
 
-        if (stats.getRepositories() != null && !stats.getRepositories().isEmpty()) {
-            sb.append("\n### 레포별 기여도\n");
-            stats.getRepositories().stream()
-                    .sorted((a, b) -> Integer.compare(b.getUserCommits(), a.getUserCommits()))
-                    .forEach(r -> sb.append(String.format("- %s: %d/%d (%.1f%%)\n",
-                            r.getName(), r.getUserCommits(), r.getTotalCommits(), r.getContributionPercentage())));
+            if (stats.getTeamMembers() != null && !stats.getTeamMembers().isEmpty()) {
+                sb.append("\n### 팀원별 기여도 (상위 10명)\n");
+                stats.getTeamMembers().stream().limit(10)
+                        .forEach(m -> sb.append(String.format("- %s: %d커밋 (%.1f%%)\n",
+                                m.getLogin(), m.getCommits(), m.getContributionPercentage())));
+            }
+
+            return sb.toString();
+        } catch (Exception e) {
+            log.error("Tool: get_org_stats {} failed", orgName, e);
+            return String.format("Error: %s 조직 분석 실패 — %s", orgName, e.getMessage());
         }
-
-        if (stats.getTeamMembers() != null && !stats.getTeamMembers().isEmpty()) {
-            sb.append("\n### 팀원별 기여도 (상위 10명)\n");
-            stats.getTeamMembers().stream().limit(10)
-                    .forEach(m -> sb.append(String.format("- %s: %d커밋 (%.1f%%)\n",
-                            m.getLogin(), m.getCommits(), m.getContributionPercentage())));
-        }
-
-        return sb.toString();
     }
 
     @Tool(description = "두 개 이상의 레포지토리를 비교 분석합니다. 각 레포의 기여도, 커밋 품질, PR 품질을 나란히 비교합니다.")
@@ -168,7 +190,7 @@ public class RepoAnalysisTools {
             @ToolParam(description = "비교할 레포 목록 (owner/repo 형식, 쉼표 구분)") String repoList,
             @ToolParam(description = "분석 대상 사용자명") String username) {
         log.info("Tool: compare_repos [{}] for {}", repoList, username);
-
+        try {
         String[] repos = repoList.split(",");
         StringBuilder sb = new StringBuilder();
         sb.append(String.format("## 레포지토리 비교 분석 — %s\n\n", username));
@@ -207,19 +229,50 @@ public class RepoAnalysisTools {
         sb.append("\n");
 
         return sb.toString();
+        } catch (Exception e) {
+            log.error("Tool: compare_repos failed", e);
+            return "Error: 레포지토리 비교 분석 실패 — " + e.getMessage();
+        }
     }
 
     @Tool(description = "사용자의 조직 목록을 조회합니다.")
     public String listOrganizations(
             @ToolParam(description = "GitHub 액세스 토큰") String token) {
         log.info("Tool: list_organizations");
-        List<Organization> orgs = graphQLService.getUserOrganizations(token);
+        try {
+            List<Organization> orgs = graphQLService.getUserOrganizations(token);
 
-        if (orgs.isEmpty()) return "소속된 조직이 없습니다.";
+            if (orgs.isEmpty()) return "소속된 조직이 없습니다.";
 
-        return orgs.stream()
-                .map(o -> String.format("- %s%s", o.getLogin(),
-                        o.getDescription() != null ? " — " + o.getDescription() : ""))
-                .collect(Collectors.joining("\n"));
+            return orgs.stream()
+                    .map(o -> String.format("- %s%s", o.getLogin(),
+                            o.getDescription() != null ? " — " + o.getDescription() : ""))
+                    .collect(Collectors.joining("\n"));
+        } catch (Exception e) {
+            log.error("Tool: list_organizations failed", e);
+            return "Error: 조직 목록 조회 실패 — " + e.getMessage();
+        }
+    }
+
+    @Tool(description = "조직(Organization)의 레포지토리 목록을 조회합니다. 조직 내 레포 이름, public/private 여부, 설명을 반환합니다. 조직 단위 분석 전에 먼저 호출하여 레포 목록을 파악합니다.")
+    public String listOrgRepos(
+            @ToolParam(description = "GitHub 액세스 토큰") String token,
+            @ToolParam(description = "조직 이름 (예: FairTicket-Lab)") String orgName) {
+        log.info("Tool: list_org_repos {}", orgName);
+        try {
+            List<GitHubRepository> repos = graphQLService.getOrganizationRepositories(token, orgName);
+
+            if (repos.isEmpty()) return orgName + " 조직에 레포지토리가 없습니다.";
+
+            return repos.stream()
+                    .map(r -> String.format("- %s (%s)%s",
+                            r.getName(),
+                            r.getIsPrivate() ? "private" : "public",
+                            r.getDescription() != null ? " — " + r.getDescription() : ""))
+                    .collect(Collectors.joining("\n"));
+        } catch (Exception e) {
+            log.error("Tool: list_org_repos {} failed", orgName, e);
+            return String.format("Error: %s 조직 레포 조회 실패 — %s", orgName, e.getMessage());
+        }
     }
 }

--- a/tally-mcp-github/src/main/java/com/devpulse/mcp/github/tools/TeamHealthTools.java
+++ b/tally-mcp-github/src/main/java/com/devpulse/mcp/github/tools/TeamHealthTools.java
@@ -24,7 +24,12 @@ public class TeamHealthTools {
             @ToolParam(description = "레포지토리 소유자") String owner,
             @ToolParam(description = "레포지토리 이름") String repo) {
         log.info("Tool: diagnose_bus_factor {}/{}", owner, repo);
-        return teamHealthService.diagnoseBusFactor(token, owner, repo);
+        try {
+            return teamHealthService.diagnoseBusFactor(token, owner, repo);
+        } catch (Exception e) {
+            log.error("Tool: diagnose_bus_factor {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s Bus Factor 진단 실패 — %s", owner, repo, e.getMessage());
+        }
     }
 
     @Tool(description = "PR 리뷰 병목을 진단합니다. 평균 첫 리뷰 시간, 머지까지 소요 시간, 현재 대기 중인 PR, 리뷰어별 응답 시간을 분석합니다. DORA 리드 타임 등급도 포함됩니다.")
@@ -33,7 +38,12 @@ public class TeamHealthTools {
             @ToolParam(description = "레포지토리 소유자") String owner,
             @ToolParam(description = "레포지토리 이름") String repo) {
         log.info("Tool: diagnose_review_bottleneck {}/{}", owner, repo);
-        return teamHealthService.diagnoseReviewBottleneck(token, owner, repo);
+        try {
+            return teamHealthService.diagnoseReviewBottleneck(token, owner, repo);
+        } catch (Exception e) {
+            log.error("Tool: diagnose_review_bottleneck {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s 리뷰 병목 진단 실패 — %s", owner, repo, e.getMessage());
+        }
     }
 
     @Tool(description = "팀원의 번아웃 위험을 감지합니다. 커밋 시간대 패턴(야간/주말 비율)을 분석하여 업무 강도 이상 징후를 식별합니다. 기여자별 위험도(정상/주의/높음)를 반환합니다.")
@@ -42,7 +52,12 @@ public class TeamHealthTools {
             @ToolParam(description = "레포지토리 소유자") String owner,
             @ToolParam(description = "레포지토리 이름") String repo) {
         log.info("Tool: diagnose_burnout_risk {}/{}", owner, repo);
-        return teamHealthService.diagnoseBurnoutRisk(token, owner, repo);
+        try {
+            return teamHealthService.diagnoseBurnoutRisk(token, owner, repo);
+        } catch (Exception e) {
+            log.error("Tool: diagnose_burnout_risk {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s 번아웃 위험 분석 실패 — %s", owner, repo, e.getMessage());
+        }
     }
 
     @Tool(description = "DORA 메트릭 4대 지표를 계산합니다. 배포 빈도, 리드 타임, 변경 실패율, MTTR을 측정하고 Elite/High/Medium/Low 등급을 부여합니다. 팀의 소프트웨어 개발 성숙도를 평가합니다.")
@@ -51,7 +66,12 @@ public class TeamHealthTools {
             @ToolParam(description = "레포지토리 소유자") String owner,
             @ToolParam(description = "레포지토리 이름") String repo) {
         log.info("Tool: calculate_dora_metrics {}/{}", owner, repo);
-        return teamHealthService.calculateDoraMetrics(token, owner, repo);
+        try {
+            return teamHealthService.calculateDoraMetrics(token, owner, repo);
+        } catch (Exception e) {
+            log.error("Tool: calculate_dora_metrics {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s DORA 메트릭 계산 실패 — %s", owner, repo, e.getMessage());
+        }
     }
 
     @Tool(description = "레포지토리의 최근 N일간 활동을 요약합니다. 커밋, PR, 이슈의 현황과 기여자별 통계를 반환합니다. 팀 현황 파악에 활용합니다.")
@@ -61,7 +81,12 @@ public class TeamHealthTools {
             @ToolParam(description = "레포지토리 이름") String repo,
             @ToolParam(description = "조회할 일수 (기본 7일)") int days) {
         log.info("Tool: get_recent_activity {}/{} days={}", owner, repo, days);
-        return teamHealthService.getRecentActivity(token, owner, repo, days);
+        try {
+            return teamHealthService.getRecentActivity(token, owner, repo, days);
+        } catch (Exception e) {
+            log.error("Tool: get_recent_activity {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s 최근 활동 조회 실패 — %s", owner, repo, e.getMessage());
+        }
     }
 
     @Tool(description = "스프린트 리포트를 자동 생성합니다. 최근 N일간의 완료 작업(feat/fix/refactor), 머지된 PR, 해결된 이슈, 진행 중인 작업, 팀 통계를 종합 요약합니다.")
@@ -71,6 +96,11 @@ public class TeamHealthTools {
             @ToolParam(description = "레포지토리 이름") String repo,
             @ToolParam(description = "스프린트 기간 일수 (기본 14일)") int days) {
         log.info("Tool: generate_sprint_report {}/{} days={}", owner, repo, days);
-        return teamHealthService.generateSprintReport(token, owner, repo, days);
+        try {
+            return teamHealthService.generateSprintReport(token, owner, repo, days);
+        } catch (Exception e) {
+            log.error("Tool: generate_sprint_report {}/{} failed", owner, repo, e);
+            return String.format("Error: %s/%s 스프린트 리포트 생성 실패 — %s", owner, repo, e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- 7개 차트 시각화 시스템 프롬프트 추가 (DORA, Bus Factor, Burnout, Commit Quality, Review Bottleneck, Compare Repos, Role Distribution)
- GitHub OAuth 로그인 구현 (AuthController + GitHubOAuthService)
- 조직 목록 API를 MCP 도구 → GitHub REST API 직접 호출로 변경 (안정성 개선)
- MCP 도구 파라미터 워크플로우 강화 (org만 지정 시 listOrgRepos 우선 호출)
- ToolCallbackConfig로 MCP 도구 등록 안정화
- CORS CorsFilter 빈 + selectedOrg 컨텍스트 지원

## Test plan
- [ ] GitHub OAuth 로그인 후 조직 드롭다운 표시 확인
- [ ] 각 차트 명령 시 JSON 포맷 출력 확인
- [ ] 조직 선택 후 owner 생략한 명령 동작 확인

Closes #43