### PR TITLE
fix: GraphQL NPE 수정 + Docker Compose healthcheck + Org 전체 분석 개선

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   tally-agent:
     build:
@@ -9,13 +7,18 @@ services:
       - "8080:8080"
     environment:
       - OPEN_AI_KEY=${OPEN_AI_KEY}
+      - GITHUB_OAUTH_CLIENT_ID=${GITHUB_OAUTH_CLIENT_ID}
+      - GITHUB_OAUTH_CLIENT_SECRET=${GITHUB_OAUTH_CLIENT_SECRET}
       - SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_GITHUB-MCP_URL=http://tally-mcp-github:8081
       - SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_K8S-MCP_URL=http://tally-mcp-k8s:8082
       - SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_MONITOR-MCP_URL=http://tally-mcp-monitor:8083
     depends_on:
-      - tally-mcp-github
-      - tally-mcp-k8s
-      - tally-mcp-monitor
+      tally-mcp-github:
+        condition: service_healthy
+      tally-mcp-k8s:
+        condition: service_healthy
+      tally-mcp-monitor:
+        condition: service_healthy
 
   tally-mcp-github:
     build:
@@ -25,6 +28,12 @@ services:
       - "8081:8081"
     environment:
       - GITHUB_TOKEN=${GITHUB_TOKEN}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 15s
 
   tally-mcp-k8s:
     build:
@@ -34,6 +43,12 @@ services:
       - "8082:8082"
     volumes:
       - ${HOME}/.kube/config:/root/.kube/config:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8082/actuator/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 15s
 
   tally-mcp-monitor:
     build:
@@ -48,3 +63,9 @@ services:
       - MONITOR_SERVICES_1_URL=http://tally-mcp-github:8081
       - MONITOR_SERVICES_2_NAME=tally-mcp-k8s
       - MONITOR_SERVICES_2_URL=http://tally-mcp-k8s:8082
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8083/actuator/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,33 @@
 services:
+  # Frontend (Nginx + React)
+  frontend:
+    build:
+      context: ../Tally-FE
+      dockerfile: Dockerfile
+    ports:
+      - "8080:80"
+    networks:
+      - app-network
+    depends_on:
+      tally-agent:
+        condition: service_healthy
+
+  # Spring AI Agent (MCP Client)
   tally-agent:
     build:
       context: ./tally-agent
       dockerfile: Dockerfile
-    ports:
-      - "8080:8080"
     environment:
       - OPEN_AI_KEY=${OPEN_AI_KEY}
       - GITHUB_OAUTH_CLIENT_ID=${GITHUB_OAUTH_CLIENT_ID}
       - GITHUB_OAUTH_CLIENT_SECRET=${GITHUB_OAUTH_CLIENT_SECRET}
+      - GITHUB_OAUTH_REDIRECT_URI=http://localhost:8080/auth/callback
+      - REPORT_FRONTEND_URL=http://localhost:8080
       - SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_GITHUB-MCP_URL=http://tally-mcp-github:8081
       - SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_K8S-MCP_URL=http://tally-mcp-k8s:8082
       - SPRING_AI_MCP_CLIENT_SSE_CONNECTIONS_MONITOR-MCP_URL=http://tally-mcp-monitor:8083
+    networks:
+      - app-network
     depends_on:
       tally-mcp-github:
         condition: service_healthy
@@ -19,43 +35,50 @@ services:
         condition: service_healthy
       tally-mcp-monitor:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/api/chat | grep -q '405' || curl -sf http://localhost:8080/ > /dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
 
+  # MCP Server - GitHub 분석
   tally-mcp-github:
     build:
       context: ./tally-mcp-github
       dockerfile: Dockerfile
-    ports:
-      - "8081:8081"
     environment:
       - GITHUB_TOKEN=${GITHUB_TOKEN}
+    networks:
+      - app-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-      start_period: 15s
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
+  # MCP Server - K8s 관리
   tally-mcp-k8s:
     build:
       context: ./tally-mcp-k8s
       dockerfile: Dockerfile
-    ports:
-      - "8082:8082"
     volumes:
       - ${HOME}/.kube/config:/root/.kube/config:ro
+    networks:
+      - app-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8082/actuator/health"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-      start_period: 15s
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
+  # MCP Server - 서비스 모니터링
   tally-mcp-monitor:
     build:
       context: ./tally-mcp-monitor
       dockerfile: Dockerfile
-    ports:
-      - "8083:8083"
     environment:
       - MONITOR_SERVICES_0_NAME=tally-agent
       - MONITOR_SERVICES_0_URL=http://tally-agent:8080
@@ -63,9 +86,15 @@ services:
       - MONITOR_SERVICES_1_URL=http://tally-mcp-github:8081
       - MONITOR_SERVICES_2_NAME=tally-mcp-k8s
       - MONITOR_SERVICES_2_URL=http://tally-mcp-k8s:8082
+    networks:
+      - app-network
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8083/actuator/health"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-      start_period: 15s
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+networks:
+  app-network:
+    driver: bridge

--- a/tally-agent/Dockerfile
+++ b/tally-agent/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8080

--- a/tally-agent/src/main/java/com/devpulse/agent/controller/AuthController.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/controller/AuthController.java
@@ -2,10 +2,13 @@ package com.devpulse.agent.controller;
 
 import com.devpulse.agent.service.GitHubOAuthService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -19,11 +22,16 @@ public class AuthController {
     }
 
     @PostMapping("/github/callback")
-    public Map<String, Object> handleCallback(@RequestBody Map<String, String> request) {
+    public ResponseEntity<?> handleCallback(@RequestBody Map<String, String> request) {
         String code = request.get("code");
         if (code == null || code.isBlank()) {
-            throw new IllegalArgumentException("Authorization code is required");
+            return ResponseEntity.badRequest().body(Map.of("error", "Authorization code is required"));
         }
-        return gitHubOAuthService.exchangeCodeForUser(code);
+        try {
+            return ResponseEntity.ok(gitHubOAuthService.exchangeCodeForUser(code));
+        } catch (Exception e) {
+            log.error("OAuth callback failed", e);
+            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+        }
     }
 }

--- a/tally-agent/src/main/java/com/devpulse/agent/service/AgentService.java
+++ b/tally-agent/src/main/java/com/devpulse/agent/service/AgentService.java
@@ -76,15 +76,22 @@ public class AgentService {
 
             MANDATORY WORKFLOW when user mentions an organization (not a specific repo):
             1. FIRST call listOrgRepos to get the list of repositories in that organization
-            2. THEN pick the main repository (prefer -BE over -FE, or the largest one)
-            3. THEN call the analysis tool with owner=orgName AND repo=repoName
-            4. Tell the user which repo you analyzed
+            2. THEN analyze ALL repositories in the organization, not just one
+            3. Call the analysis tool for EACH repo: owner=orgName, repo=eachRepoName
+            4. If a tool call fails for a specific repo, log it and continue with the next repo — do NOT stop
+            5. After analyzing all repos, present a COMBINED summary with per-repo breakdown
+            6. Clearly label each repo's results so the user can see individual and overall status
 
-            Example: User says "Farm-On bus factor 분석해줘"
-            → Step 1: call listOrgRepos(token, "Farm-On") → gets ["FE", "BE"]
-            → Step 2: pick "BE" as main repo
-            → Step 3: call diagnoseBusFactor(token, "Farm-On", "BE")
+            Example: User says "FairTicket-Lab DORA 메트릭 분석해줘"
+            → Step 1: call listOrgRepos(token, "FairTicket-Lab") → gets ["FairTicket-FE", "FairTicket-BE", "FairTicket-Infra"]
+            → Step 2: call calculateDoraMetrics for EACH repo:
+              - calculateDoraMetrics(token, "FairTicket-Lab", "FairTicket-FE")
+              - calculateDoraMetrics(token, "FairTicket-Lab", "FairTicket-BE")
+              - calculateDoraMetrics(token, "FairTicket-Lab", "FairTicket-Infra")
+            → Step 3: combine results into org-wide summary + per-repo details
+            → Step 4: if FairTicket-Infra failed (e.g. empty repo), note it and show results for the others
 
+            IMPORTANT: If a specific repo is mentioned (e.g. "FairTicket-BE 분석해줘"), analyze ONLY that repo.
             If the user's GitHub Context below already lists repos for that org, you may skip listOrgRepos.
 
             ### Kubernetes Cluster Management

--- a/tally-mcp-github/Dockerfile
+++ b/tally-mcp-github/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8081

--- a/tally-mcp-github/build.gradle.kts
+++ b/tally-mcp-github/build.gradle.kts
@@ -6,6 +6,9 @@ dependencies {
     // Spring AI - MCP Server (WebMVC transport with SSE)
     implementation("org.springframework.ai:spring-ai-starter-mcp-server-webmvc")
 
+    // Actuator
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
     // Jackson
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/tally-mcp-github/src/main/java/com/devpulse/mcp/github/service/GitHubGraphQLClient.java
+++ b/tally-mcp-github/src/main/java/com/devpulse/mcp/github/service/GitHubGraphQLClient.java
@@ -49,12 +49,33 @@ public class GitHubGraphQLClient {
             JsonNode response = objectMapper.readTree(responseBody);
 
             if (response.has("errors")) {
-                log.error("GraphQL errors: {}", response.get("errors"));
-                throw new RuntimeException("GraphQL query failed: " + response.get("errors"));
+                JsonNode errors = response.get("errors");
+                log.error("GraphQL errors: {}", errors);
+
+                String firstMessage = errors.isArray() && errors.size() > 0
+                        ? errors.get(0).path("message").asText("Unknown error")
+                        : errors.toString();
+                String errorType = errors.isArray() && errors.size() > 0
+                        ? errors.get(0).path("type").asText("")
+                        : "";
+
+                if (firstMessage.contains("rate limit") || firstMessage.contains("API rate")) {
+                    throw new RuntimeException("GitHub API rate limit exceeded. Please wait and retry. Detail: " + firstMessage);
+                } else if ("NOT_FOUND".equals(errorType) || firstMessage.contains("Could not resolve")) {
+                    throw new RuntimeException("GitHub resource not found: " + firstMessage);
+                } else if (firstMessage.contains("Field") && firstMessage.contains("doesn't exist")) {
+                    throw new RuntimeException("GraphQL schema error — requested field does not exist: " + firstMessage);
+                } else if ("FORBIDDEN".equals(errorType) || firstMessage.contains("forbidden") || firstMessage.contains("insufficient")) {
+                    throw new RuntimeException("Insufficient permissions for this GitHub resource: " + firstMessage);
+                } else {
+                    throw new RuntimeException("GraphQL query failed: " + firstMessage);
+                }
             }
 
             return response.get("data");
 
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Failed to execute GraphQL query", e);
             throw new RuntimeException("GraphQL execution failed", e);
@@ -91,8 +112,6 @@ public class GitHubGraphQLClient {
                                   avatarUrl
                                 }
                               }
-                              additions
-                              deletions
                             }
                           }
                         }
@@ -181,8 +200,6 @@ public class GitHubGraphQLClient {
                               avatarUrl
                             }
                           }
-                          additions
-                          deletions
                         }
                       }
                     }

--- a/tally-mcp-github/src/main/java/com/devpulse/mcp/github/service/TeamHealthService.java
+++ b/tally-mcp-github/src/main/java/com/devpulse/mcp/github/service/TeamHealthService.java
@@ -33,8 +33,16 @@ public class TeamHealthService {
             throw new RuntimeException("Repository not found: " + owner + "/" + repo);
         }
 
-        JsonNode commitsNode = repoNode.get("defaultBranchRef").get("target").get("history").get("nodes");
-        int totalCommitCount = repoNode.get("defaultBranchRef").get("target").get("history").get("totalCount").asInt();
+        if (!repoNode.has("defaultBranchRef") || repoNode.get("defaultBranchRef").isNull()) {
+            return String.format("## %s/%s Bus Factor 진단\n\n기본 브랜치가 없습니다. 빈 레포지토리이거나 기본 브랜치가 설정되지 않았습니다.", owner, repo);
+        }
+        JsonNode defaultBranchRef = repoNode.get("defaultBranchRef");
+        JsonNode target = defaultBranchRef.get("target");
+        if (target == null || target.isNull() || !target.has("history")) {
+            return String.format("## %s/%s Bus Factor 진단\n\n커밋 히스토리를 가져올 수 없습니다.", owner, repo);
+        }
+        JsonNode commitsNode = target.get("history").get("nodes");
+        int totalCommitCount = target.get("history").get("totalCount").asInt();
 
         // 기여자별 커밋 수 집계
         Map<String, Integer> authorCommits = new LinkedHashMap<>();
@@ -44,8 +52,12 @@ public class TeamHealthService {
         for (JsonNode commit : commitsNode) {
             String author = extractAuthorLogin(commit);
             authorCommits.merge(author, 1, Integer::sum);
-            authorAdditions.merge(author, commit.get("additions").asInt(), Integer::sum);
-            authorDeletions.merge(author, commit.get("deletions").asInt(), Integer::sum);
+            if (commit.has("additions") && !commit.get("additions").isNull()) {
+                authorAdditions.merge(author, commit.get("additions").asInt(), Integer::sum);
+            }
+            if (commit.has("deletions") && !commit.get("deletions").isNull()) {
+                authorDeletions.merge(author, commit.get("deletions").asInt(), Integer::sum);
+            }
         }
 
         int analyzedCommits = 0;
@@ -153,6 +165,7 @@ public class TeamHealthService {
 
             if ("MERGED".equals(state)) {
                 mergedCount++;
+                if (!pr.has("mergedAt") || pr.get("mergedAt").isNull()) continue;
                 String mergedAt = pr.get("mergedAt").asText();
                 try {
                     long mergeHours = ChronoUnit.HOURS.between(
@@ -259,7 +272,14 @@ public class TeamHealthService {
             throw new RuntimeException("Repository not found: " + owner + "/" + repo);
         }
 
-        JsonNode commitsNode = repoNode.get("defaultBranchRef").get("target").get("history").get("nodes");
+        if (!repoNode.has("defaultBranchRef") || repoNode.get("defaultBranchRef").isNull()) {
+            return String.format("## %s/%s 번아웃 위험 분석\n\n기본 브랜치가 없습니다. 빈 레포지토리이거나 기본 브랜치가 설정되지 않았습니다.", owner, repo);
+        }
+        JsonNode branchTarget = repoNode.get("defaultBranchRef").get("target");
+        if (branchTarget == null || branchTarget.isNull() || !branchTarget.has("history")) {
+            return String.format("## %s/%s 번아웃 위험 분석\n\n커밋 히스토리를 가져올 수 없습니다.", owner, repo);
+        }
+        JsonNode commitsNode = branchTarget.get("history").get("nodes");
 
         // 기여자별 커밋 시간대 분석
         Map<String, List<ZonedDateTime>> authorTimestamps = new LinkedHashMap<>();
@@ -367,7 +387,14 @@ public class TeamHealthService {
             throw new RuntimeException("Repository not found: " + owner + "/" + repo);
         }
 
-        JsonNode commitsNode = repoNode.get("defaultBranchRef").get("target").get("history").get("nodes");
+        if (!repoNode.has("defaultBranchRef") || repoNode.get("defaultBranchRef").isNull()) {
+            return String.format("## %s/%s DORA 메트릭\n\n기본 브랜치가 없습니다. 빈 레포지토리이거나 기본 브랜치가 설정되지 않았습니다.", owner, repo);
+        }
+        JsonNode doraTarget = repoNode.get("defaultBranchRef").get("target");
+        if (doraTarget == null || doraTarget.isNull() || !doraTarget.has("history")) {
+            return String.format("## %s/%s DORA 메트릭\n\n커밋 히스토리를 가져올 수 없습니다.", owner, repo);
+        }
+        JsonNode commitsNode = doraTarget.get("history").get("nodes");
         JsonNode prsNode = repoNode.get("pullRequests").get("nodes");
         JsonNode issuesNode = repoNode.get("issues").get("nodes");
 
@@ -380,6 +407,7 @@ public class TeamHealthService {
 
         for (JsonNode pr : prsNode) {
             if (!"MERGED".equals(pr.get("state").asText())) continue;
+            if (!pr.has("mergedAt") || pr.get("mergedAt").isNull()) continue;
 
             String mergedAt = pr.get("mergedAt").asText();
             String createdAt = pr.get("createdAt").asText();
@@ -424,6 +452,7 @@ public class TeamHealthService {
 
             if (title.contains("bug") || title.contains("fix") || title.contains("error")
                     || body.contains("bug") || body.contains("error")) {
+                if (!issue.has("closedAt") || issue.get("closedAt").isNull()) continue;
                 try {
                     ZonedDateTime created = ZonedDateTime.parse(issue.get("createdAt").asText());
                     ZonedDateTime closed = ZonedDateTime.parse(issue.get("closedAt").asText());
@@ -512,7 +541,14 @@ public class TeamHealthService {
 
         ZonedDateTime cutoff = ZonedDateTime.now().minusDays(days);
 
-        JsonNode commitsNode = repoNode.get("defaultBranchRef").get("target").get("history").get("nodes");
+        if (!repoNode.has("defaultBranchRef") || repoNode.get("defaultBranchRef").isNull()) {
+            return String.format("## %s/%s 최근 %d일 활동 요약\n\n기본 브랜치가 없습니다. 빈 레포지토리이거나 기본 브랜치가 설정되지 않았습니다.", owner, repo, days);
+        }
+        JsonNode activityTarget = repoNode.get("defaultBranchRef").get("target");
+        if (activityTarget == null || activityTarget.isNull() || !activityTarget.has("history")) {
+            return String.format("## %s/%s 최근 %d일 활동 요약\n\n커밋 히스토리를 가져올 수 없습니다.", owner, repo, days);
+        }
+        JsonNode commitsNode = activityTarget.get("history").get("nodes");
         JsonNode prsNode = repoNode.get("pullRequests").get("nodes");
         JsonNode issuesNode = repoNode.get("issues").get("nodes");
 
@@ -640,7 +676,14 @@ public class TeamHealthService {
         ZonedDateTime now = ZonedDateTime.now();
         ZonedDateTime cutoff = now.minusDays(days);
 
-        JsonNode commitsNode = repoNode.get("defaultBranchRef").get("target").get("history").get("nodes");
+        if (!repoNode.has("defaultBranchRef") || repoNode.get("defaultBranchRef").isNull()) {
+            return String.format("## %s/%s 스프린트 리포트\n\n기본 브랜치가 없습니다. 빈 레포지토리이거나 기본 브랜치가 설정되지 않았습니다.", owner, repo);
+        }
+        JsonNode sprintTarget = repoNode.get("defaultBranchRef").get("target");
+        if (sprintTarget == null || sprintTarget.isNull() || !sprintTarget.has("history")) {
+            return String.format("## %s/%s 스프린트 리포트\n\n커밋 히스토리를 가져올 수 없습니다.", owner, repo);
+        }
+        JsonNode commitsNode = sprintTarget.get("history").get("nodes");
         JsonNode prsNode = repoNode.get("pullRequests").get("nodes");
         JsonNode issuesNode = repoNode.get("issues").get("nodes");
 

--- a/tally-mcp-github/src/main/resources/application.yml
+++ b/tally-mcp-github/src/main/resources/application.yml
@@ -18,6 +18,15 @@ spring:
 server:
   port: 8081
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always
+
 logging:
   level:
     com.devpulse: DEBUG

--- a/tally-mcp-k8s/Dockerfile
+++ b/tally-mcp-k8s/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8082

--- a/tally-mcp-k8s/src/main/resources/application.yml
+++ b/tally-mcp-k8s/src/main/resources/application.yml
@@ -15,6 +15,15 @@ spring:
 server:
   port: 8082
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always
+
 logging:
   level:
     com.devpulse: DEBUG

--- a/tally-mcp-monitor/Dockerfile
+++ b/tally-mcp-monitor/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8083


### PR DESCRIPTION
## Summary
- GraphQL 분석 시 NPE 발생하던 5개 버그 수정 (defaultBranchRef, mergedAt, closedAt, additions/deletions null 체크)
- Docker Compose 동시 기동 시 tally-agent 실패 문제 해결 (healthcheck + service_healthy 조건)
- Organization 분석 시 전체 레포 순회하며 종합 결과 제시하도록 개선

## Changes (12 files)
| 영역 | 파일 | 변경 |
|------|------|------|
| GraphQL 버그 | TeamHealthService.java | 5개 메서드 null 체크 추가 |
| GraphQL 버그 | GitHubGraphQLClient.java | additions/deletions 쿼리 제거, 에러 분류 |
| Docker | docker-compose.yml | healthcheck + service_healthy |
| Docker | Dockerfile x4 | curl 설치 |
| Actuator | mcp-github/k8s application.yml | health endpoint 추가 |
| Actuator | mcp-github build.gradle.kts | actuator 의존성 추가 |
| Agent | AgentService.java | org 전체 레포 순회 분석 프롬프트 |
| Auth | AuthController.java | 기존 변경 포함 |

## Test plan
- [x] `docker compose up` 한 번에 전체 기동 확인 (healthcheck 정상 동작)
- [ ] FairTicket-Lab org DORA 메트릭 분석 요청 → 전체 레포 순회 결과 확인
- [ ] 빈 레포/private 레포 포함 org 분석 시 개별 실패 허용 확인
- [ ] GitHub OAuth 로그인 정상 동작 확인

closes #51